### PR TITLE
fix: add safeguards to git clone when creating stack from git URL

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,7 @@ export default [
         HTMLSelectElement: "readonly",
         HTMLTextAreaElement: "readonly",
         requestAnimationFrame: "readonly",
+        URL: "readonly",
       },
     },
     plugins: {

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -72,7 +72,12 @@ export function makeTempDir(): CockpitProcess {
 
 // Shallow-clone repo to caller-provided tmpdir. Caller reads compose file then calls removeDirectory.
 export function fetchComposeFromGit(url: string, tmpDir: string, superuser?: "try"): CockpitProcess {
-  return cockpit.spawn(["git", "clone", "--depth", "1", "--", url, tmpDir], { superuser, err: "out" });
+  return cockpit.spawn(
+    ["git", "clone", "--depth", "1", "--no-local",
+     "--config", "core.hooksPath=/dev/null",
+     "--filter=blob:none", "--", url, tmpDir],
+    { superuser, err: "out" },
+  );
 }
 
 export function removeDirectory(path: string, superuser?: "try"): CockpitProcess {

--- a/src/components/CreateStackModal.test.tsx
+++ b/src/components/CreateStackModal.test.tsx
@@ -329,6 +329,36 @@ describe("CreateStackModal — step 2 git url", () => {
     expect(screen.getByRole("button", { name: /Create/i })).toBeDisabled();
   });
 
+  it("rejects non-https URL without cloning", async () => {
+    render(<CreateStackModal {...defaultProps} />);
+    await fillSetupAndAdvance("git");
+    fireEvent.change(screen.getByPlaceholderText(/github.com/i), {
+      target: { value: "file:///etc/passwd" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Fetch/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/only http/i)).toBeInTheDocument();
+    });
+    expect(mockFetchComposeFromGit).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-URL string without cloning", async () => {
+    render(<CreateStackModal {...defaultProps} />);
+    await fillSetupAndAdvance("git");
+    fireEvent.change(screen.getByPlaceholderText(/github.com/i), {
+      target: { value: "../../../etc/passwd" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Fetch/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/only http/i)).toBeInTheDocument();
+    });
+    expect(mockFetchComposeFromGit).not.toHaveBeenCalled();
+  });
+
   it("successful fetch shows editor and security warning", async () => {
     const yaml = "services:\n  app:\n    image: test:latest\n";
     mockMakeTempDir.mockImplementation(() => mockProcess("/tmp/test123\n"));

--- a/src/components/CreateStackModal.tsx
+++ b/src/components/CreateStackModal.tsx
@@ -108,6 +108,18 @@ export function CreateStackModal({ stacks, onClose, onCreated }: Props) {
   }, [composeDir, stackName]);
 
   const handleFetchGit = useCallback(async () => {
+    const url = gitUrl.trim();
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+        setGitError("Only http:// and https:// URLs are supported");
+        return;
+      }
+    } catch {
+      setGitError("Invalid URL — only http:// and https:// URLs are supported");
+      return;
+    }
+
     setFetching(true);
     setGitError(null);
     setFetchedYaml(null);
@@ -119,7 +131,7 @@ export function CreateStackModal({ stacks, onClose, onCreated }: Props) {
       await mkProc;
       tmpDir = tmpOut.trim();
 
-      const cloneProc = fetchComposeFromGit(gitUrl.trim(), tmpDir);
+      const cloneProc = fetchComposeFromGit(url, tmpDir);
       await cloneProc;
 
       // Try to read compose file from repo root


### PR DESCRIPTION
## Description

[Git import runs git clone as root](fix: run compose commands depending on ownership as superuser)

## Type

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
