### PR TITLE
test: cover env file linting

### DIFF
--- a/src/components/envLint.test.ts
+++ b/src/components/envLint.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { lintEnvContent } from "./envLint";
+
+describe("lintEnvContent", () => {
+  it("ignores blank lines, comments, and valid assignments", () => {
+    const diagnostics = lintEnvContent(
+      ["", "# comment", "APP_ENV=production", "_TOKEN=value", "PORT=8080"].join(
+        "\n",
+      ),
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("reports lines without an equals sign", () => {
+    const diagnostics = lintEnvContent("APP_ENV");
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      from: 0,
+      to: 7,
+      severity: "error",
+      message: "Missing '=': expected KEY=VALUE",
+    });
+  });
+
+  it("warns when spaces surround an assignment", () => {
+    const diagnostics = lintEnvContent("APP_ENV = production");
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      from: 0,
+      to: 8,
+      severity: "warning",
+      message: "Avoid spaces around '='",
+    });
+  });
+
+  it("warns when a value starts with leading whitespace", () => {
+    const diagnostics = lintEnvContent("APP_ENV= production");
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      from: 8,
+      to: 19,
+      severity: "warning",
+      message: "Avoid spaces around '='",
+    });
+  });
+
+  it("reports invalid key names", () => {
+    const diagnostics = lintEnvContent("1APP_ENV=production");
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      from: 0,
+      to: 8,
+      severity: "error",
+      message:
+        "Invalid key name: must start with a letter or underscore and contain only letters, digits, or underscores",
+    });
+  });
+
+  it("warns about duplicate keys", () => {
+    const diagnostics = lintEnvContent("APP_ENV=production\nAPP_ENV=local");
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      from: 19,
+      to: 26,
+      severity: "warning",
+      message: "Duplicate key: APP_ENV",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused unit coverage for `lintEnvFile()` in `src/components/envLint.ts`, including valid lines and the error cases called out by the current uncovered file:

- missing `=` assignment
- spaces around assignment
- leading whitespace after `=`
- invalid key names
- duplicate keys

## Validation

I used the bundled Node runtime because the local `/usr/local/bin/node` was v22.11.0 while the package requires Node >=22.12 or >=24.

- `PATH=/Users/stephenkall/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- src/components/envLint.test.ts`
- `PATH=/Users/stephenkall/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run lint`
- `PATH=/Users/stephenkall/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run typecheck`
- `PATH=/Users/stephenkall/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build`
- `git diff --check HEAD~1 HEAD`

Submitted by Bean Labs as a public free-service contribution; acceptance is still pending maintainer review.
