### PR TITLE
fix: adds suggest podman dialog if no docker installation found

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Docker Compose management for [Cockpit](https://cockpit-project.org) — start, 
 - Live log viewer per stack
 - Interactive shell into any running service
 - YAML editor with syntax validation and auto-snapshot before saving + .ENV editor
+- Podman compatibility mode (Experimental)
 
 ## Requirements
 
@@ -22,6 +23,8 @@ Docker Compose management for [Cockpit](https://cockpit-project.org) — start, 
 - Docker with the Compose plugin (`docker compose` v2+)
 
 ## Prerequisites
+
+You can use either Docker Compose, Podman Compose(Docker redirect) or pure podman-compose mode as your container engine. Be mindful that this plugin is primarly for Docker Compose. The pure podman-compose case (No docker installed) might lead to a degraded UIUX experience.
 
 Docker is not installed by default on most distros. Install it and make sure it is running and add your user to the docker group. Works with rootless docker by setting DOCKER_HOST env in OS.
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Page, PageSection } from "@patternfly/react-core";
 import { AppFooter } from "./AppFooter";
@@ -12,9 +12,16 @@ export function App() {
   const [runtime, setRuntime] = useState<Runtime>(
     () => (localStorage.getItem("cockpit-compose:runtime") ?? "docker") as Runtime,
   );
+  const [dockerMissing, setDockerMissing] = useState(false);
+  const initialRuntime = useRef(runtime);
 
   useEffect(() => {
-    void detectDockerMode().then(() => detectComposeCommand()).then(() => setReady(true));
+    void detectDockerMode()
+      .then(() => detectComposeCommand())
+      .then(found => {
+        if (initialRuntime.current === "docker" && !found) setDockerMissing(true);
+        setReady(true);
+      });
   }, []);
 
   if (!ready) return null;
@@ -23,7 +30,7 @@ export function App() {
     <Page className="pf-m-no-sidebar">
       <PageSection hasBodyWrapper={false} isFilled>
         <ErrorBoundary fallbackTitle={t("error_boundary.load_stacks_error")}>
-          <StacksView onRuntimeChange={setRuntime} />
+          <StacksView onRuntimeChange={setRuntime} dockerMissing={dockerMissing} />
         </ErrorBoundary>
       </PageSection>
       <AppFooter runtime={runtime} />

--- a/src/components/RuntimeToggle.tsx
+++ b/src/components/RuntimeToggle.tsx
@@ -6,6 +6,7 @@ import { setRuntime, detectComposeCommand, type Runtime } from "../api";
 
 interface Props {
   onRuntimeChange?: (runtime: Runtime) => void;
+  suggestPodman?: boolean;
 }
 
 function DockerIcon() {
@@ -20,14 +21,14 @@ function PodmanIcon() {
   return <CubeIcon aria-hidden="true" style={{ marginRight: 4, verticalAlign: "middle" }} />;
 }
 
-export function RuntimeToggle({ onRuntimeChange }: Props) {
+export function RuntimeToggle({ onRuntimeChange, suggestPodman }: Props) {
   const { t } = useTranslation();
   const [runtime, setRuntimeState] = useState<Runtime>(
     () => (localStorage.getItem("cockpit-compose:runtime") ?? "docker") as Runtime,
   );
   const [detecting, setDetecting] = useState(false);
   const [notInstalled, setNotInstalled] = useState<Runtime | null>(null);
-  const [showPodmanConfirm, setShowPodmanConfirm] = useState(false);
+  const [showPodmanConfirm, setShowPodmanConfirm] = useState(() => suggestPodman ?? false);
 
   const handleChange = useCallback(async (newRuntime: Runtime) => {
     if (newRuntime === runtime || detecting) return;
@@ -89,6 +90,15 @@ export function RuntimeToggle({ onRuntimeChange }: Props) {
         <Modal isOpen onClose={() => setShowPodmanConfirm(false)} variant="small" aria-label={t("runtime.podman_confirm_title")}>
           <ModalHeader title={t("runtime.podman_confirm_title")} />
           <ModalBody>
+            {suggestPodman && (
+              <Alert
+                variant="info"
+                isInline
+                isPlain
+                title={t("runtime.podman_suggest_docker_missing")}
+                style={{ marginBottom: "0.5rem" }}
+              />
+            )}
             <Alert variant="warning" isInline isPlain title={t("runtime.podman_confirm_body")} />
           </ModalBody>
           <ModalFooter>

--- a/src/components/StacksView/index.tsx
+++ b/src/components/StacksView/index.tsx
@@ -46,9 +46,10 @@ import { splitConfigFiles } from "../../lib/configFiles";
 
 interface Props {
   onRuntimeChange?: (runtime: Runtime) => void;
+  dockerMissing?: boolean;
 }
 
-export function StacksView({ onRuntimeChange }: Props) {
+export function StacksView({ onRuntimeChange, dockerMissing }: Props) {
   const { t } = useTranslation();
   const { stacks, loading, error, refresh, reset } = useComposeStacks();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -121,7 +122,7 @@ export function StacksView({ onRuntimeChange }: Props) {
             <Title headingLevel="h2">{t("stacks.title")}</Title>
           </ToolbarItem>
           <ToolbarItem align={{ default: "alignEnd" }}>
-            <RuntimeToggle onRuntimeChange={(r) => { setRuntimeSwitchKey(k => k + 1); reset(); onRuntimeChange?.(r); }} />
+            <RuntimeToggle onRuntimeChange={(r) => { setRuntimeSwitchKey(k => k + 1); reset(); onRuntimeChange?.(r); }} suggestPodman={dockerMissing} />
           </ToolbarItem>
         </ToolbarContent>
       </Toolbar>


### PR DESCRIPTION
## Description

adds a modal if no docker installation found so the user is directed to try out podman.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
