### PR TITLE
docs: add SECURITY.md with vulnerability reporting process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,7 @@ BREAKING CHANGE: old configuration files are no longer supported
 - **Bug?** Open an issue with `[BUG]` in the title, include environment details and steps to reproduce
 - **Feature request?** Open an issue with `[FEATURE]` in the title, describe the problem being solved
 - **Question?** GitHub Discussions (coming soon) or open an issue marked `[QUESTION]`
+- **Security vulnerability?** Do **not** open a public issue. Follow the private disclosure process in [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Bug reports and feature requests: open an issue on [GitHub](https://github.com/R
 
 Pull requests are welcome. Please make sure your changes pass CI (lint, typecheck, tests, and build) before submitting. See [CONTRIBUTING.md](CONTRIBUTING.md) for commit conventions and development setup. Open an issue first for significant feature additions.
 
+## Security
+
+Found a security vulnerability? Please report it privately — see [SECURITY.md](SECURITY.md) for the disclosure process. Do not open a public issue for security reports.
+
 ## License
 
 MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+`cockpit-compose` is a Cockpit plugin that manages Docker and Podman Compose
+stacks on a user's server. Because it operates with privileged access to
+container runtimes, we take security reports seriously and appreciate
+responsible disclosure.
+
+## Supported Versions
+
+Security fixes are released for the latest published version. We recommend
+always running the most recent release.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest release | :white_check_mark: |
+| Older releases | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, use one of the private channels below:
+
+1. **GitHub private vulnerability reporting (preferred).** Open a report via the
+   repository's
+   [Security tab → "Report a vulnerability"](https://github.com/RXTX4816/cockpit-compose/security/advisories/new).
+   This keeps the discussion private until a fix is available.
+2. **Email.** If you cannot use GitHub advisories, contact the maintainer
+   through their [GitHub profile](https://github.com/RXTX4816).
+
+Please include as much detail as possible so we can reproduce and address the
+issue quickly:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof of concept
+- Affected version(s) and environment (Cockpit version, Docker/Podman, OS)
+- Any suggested remediation, if known
+
+## Response Process
+
+- We aim to **acknowledge your report within 5 business days**.
+- We will keep you informed of our progress as we investigate and work on a fix.
+- Once a fix is available, we will coordinate a disclosure timeline with you and
+  credit you for the report unless you prefer to remain anonymous.
+
+Thank you for helping keep `cockpit-compose` and its users safe.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` security policy at the repository root so GitHub surfaces vulnerability reporting guidance in the repository **Security** tab, and links it from the existing documentation.

Since this plugin manages Docker/Podman Compose stacks with privileged access to container runtimes, a documented disclosure path is important.

### Changes
- **`SECURITY.md`** (new): defines the disclosure process
  - Preferred channel: GitHub private vulnerability reporting (private security advisories), with email fallback via the maintainer's GitHub profile
  - Acknowledgment window: within 5 business days
  - Supported versions policy table (latest release supported)
  - Guidance on what details to include in a report
- **`README.md`**: adds a **Security** section linking to `SECURITY.md`
- **`CONTRIBUTING.md`**: adds a security-vulnerability entry under *Reporting Issues* pointing to `SECURITY.md`

Closes #188

## Testing
- No markdown lint/build tooling is configured in the repo (checked `package.json` scripts and CI workflow).
- Verified changed files, internal links, and markdown structure manually.
- `git status` confirms only the three intended files changed.

---
🤖 *Generated by Computer*