### PR TITLE
fix: suggest home directory as compose root when rootless (#192)

### DIFF
--- a/e2e/rootless-compose-root.spec.ts
+++ b/e2e/rootless-compose-root.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
+
+// Only meaningful on podman VMs: docker here always runs rootful
+// (see scripts/test-vm.config.sh), so the rootless suggestion never applies there.
+test('Create Stack suggests the home directory when rootless and no stacks exist yet', async ({ pluginPage: page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes('podman'), 'podman-only: docker VMs here run rootful');
+
+  await page.getByRole('button', { name: 'Create' }).click();
+  const dirInput = page.getByLabel('Compose root directory');
+  await expect(dirInput).toHaveValue(/^\/home\/test\/compose$/);
+});

--- a/src/components/CreateStackModal.test.tsx
+++ b/src/components/CreateStackModal.test.tsx
@@ -8,10 +8,12 @@ const {
   mockFetchComposeFromGit,
   mockRemoveDirectory,
   mockCreateDirectory,
+  mockIsRootlessMode,
   mockRead,
   mockReplace,
   mockCockpitFile,
   mockCockpitSpawn,
+  mockCockpitUser,
 } = vi.hoisted(() => {
   const mockRead = vi.fn();
   const mockReplace = vi.fn().mockResolvedValue(undefined);
@@ -21,10 +23,12 @@ const {
     mockFetchComposeFromGit: vi.fn(),
     mockRemoveDirectory: vi.fn(),
     mockCreateDirectory: vi.fn(),
+    mockIsRootlessMode: vi.fn(() => false),
     mockRead,
     mockReplace,
     mockCockpitFile,
     mockCockpitSpawn: vi.fn(),
+    mockCockpitUser: vi.fn().mockResolvedValue({ home: "/home/test" }),
   };
 });
 
@@ -36,14 +40,19 @@ vi.mock("../api", async (importOriginal) => {
     fetchComposeFromGit: mockFetchComposeFromGit,
     removeDirectory: mockRemoveDirectory,
     createDirectory: mockCreateDirectory,
+    isRootlessMode: mockIsRootlessMode,
   };
 });
+
+const { mockInferComposeRoot } = vi.hoisted(() => ({
+  mockInferComposeRoot: vi.fn(() => "/etc/docker/compose"),
+}));
 
 vi.mock("./DownedStacksSection", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./DownedStacksSection")>();
   return {
     ...actual,
-    inferComposeRoot: vi.fn(() => "/etc/docker/compose"),
+    inferComposeRoot: mockInferComposeRoot,
   };
 });
 
@@ -62,9 +71,12 @@ beforeEach(() => {
   mockReplace.mockReset().mockResolvedValue(undefined);
   mockCockpitFile.mockReset().mockReturnValue({ read: mockRead, replace: mockReplace });
   mockCockpitSpawn.mockReset();
+  mockIsRootlessMode.mockReset().mockReturnValue(false);
+  mockInferComposeRoot.mockReset().mockReturnValue("/etc/docker/compose");
+  mockCockpitUser.mockReset().mockResolvedValue({ home: "/home/test" });
   // Default: ls fails (dir does not exist — proceed without folder-exists error)
   mockCockpitSpawn.mockImplementation(() => mockProcess("", "No such file or directory"));
-  vi.stubGlobal("cockpit", { spawn: mockCockpitSpawn, file: mockCockpitFile });
+  vi.stubGlobal("cockpit", { spawn: mockCockpitSpawn, file: mockCockpitFile, user: mockCockpitUser });
 });
 
 import { CreateStackModal } from "./CreateStackModal";
@@ -169,6 +181,29 @@ describe("CreateStackModal — step 1 rendering", () => {
     render(<CreateStackModal {...defaultProps} onClose={onClose} />);
     fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("CreateStackModal — rootless compose dir suggestion (no stacks yet)", () => {
+  beforeEach(() => {
+    // No stacks yet: inferComposeRoot returns "" as it would for a real empty list
+    mockInferComposeRoot.mockReturnValue("");
+  });
+
+  it("defaults to the user's home directory when rootless", async () => {
+    mockIsRootlessMode.mockReturnValue(true);
+    render(<CreateStackModal {...defaultProps} stacks={[]} />);
+    await waitFor(() => {
+      const dirInput = screen.getByPlaceholderText("/etc/docker/compose") as HTMLInputElement;
+      expect(dirInput.value).toBe("/home/test/compose");
+    });
+  });
+
+  it("keeps the field empty (default placeholder) when rootful", async () => {
+    mockIsRootlessMode.mockReturnValue(false);
+    render(<CreateStackModal {...defaultProps} stacks={[]} />);
+    const dirInput = screen.getByPlaceholderText("/etc/docker/compose") as HTMLInputElement;
+    expect(dirInput.value).toBe("");
   });
 });
 

--- a/src/components/CreateStackModal.tsx
+++ b/src/components/CreateStackModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { load } from "js-yaml";
@@ -17,7 +17,7 @@ import {
   InputGroupItem,
 } from "@patternfly/react-core";
 import { CodeBranchIcon, CubesIcon, PencilAltIcon } from "@patternfly/react-icons";
-import { type ComposeStack, COMPOSE_TEMPLATES, type ComposeTemplate, makeTempDir, fetchComposeFromGit, removeDirectory, createDirectory } from "../api";
+import { type ComposeStack, COMPOSE_TEMPLATES, type ComposeTemplate, makeTempDir, fetchComposeFromGit, removeDirectory, createDirectory, isRootlessMode } from "../api";
 import { type DownedStack } from "../hooks/useDownedStacksScan";
 import { inferComposeRoot } from "./DownedStacksSection";
 import { composeFileSuperuser } from "../api";
@@ -77,6 +77,13 @@ function generateStackName() {
   return `stack-${Math.floor(1000000 + Math.random() * 9000000)}`;
 }
 
+function defaultComposeDir(stacks: ComposeStack[], userHome: string | null): string {
+  const root = inferComposeRoot(stacks);
+  if (root) return root;
+  if (isRootlessMode() && userHome) return `${userHome}/compose`;
+  return "";
+}
+
 export function CreateStackModal({ stacks, onClose, onCreated }: Props) {
   const { t } = useTranslation();
   const [step, setStep] = useState<Step>("setup");
@@ -85,12 +92,27 @@ export function CreateStackModal({ stacks, onClose, onCreated }: Props) {
   const [stackName, setStackName] = useState(() => generateStackName());
   const [composeDir, setComposeDir] = useState("");
   const [method, setMethod] = useState<Method | null>(null);
+  const [userHome, setUserHome] = useState<string | null>(null);
 
-  // Prefill compose dir from active stacks on mount
   useEffect(() => {
-    const root = inferComposeRoot(stacks);
-    if (root) setComposeDir(root);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    try {
+      cockpit.user().then(u => setUserHome(u.home)).catch(() => {});
+    } catch { /* cockpit.user unavailable */ }
+  }, []);
+
+  // Prefill compose dir from active stacks (or, if none exist yet and running
+  // rootless, the current user's home directory) on mount. Guarded by a ref
+  // since userHome resolves asynchronously — without it, this would re-fire
+  // once cockpit.user() resolves and clobber a value the user already typed.
+  const didPrefillDirRef = useRef(false);
+  useEffect(() => {
+    if (didPrefillDirRef.current) return;
+    const dir = defaultComposeDir(stacks, userHome);
+    if (dir) {
+      didPrefillDirRef.current = true;
+      setComposeDir(dir);
+    }
+  }, [userHome]); // eslint-disable-line react-hooks/exhaustive-deps
   const [setupError, setSetupError] = useState<string | null>(null);
   const [checkingDir, setCheckingDir] = useState(false);
 
@@ -121,8 +143,8 @@ export function CreateStackModal({ stacks, onClose, onCreated }: Props) {
   const canNext = !nameError && composeDir.trim() !== "" && method !== null;
 
   const handleFindBestMatch = useCallback(() => {
-    setComposeDir(inferComposeRoot(stacks));
-  }, [stacks]);
+    setComposeDir(defaultComposeDir(stacks, userHome));
+  }, [stacks, userHome]);
 
   const handleNext = useCallback(async () => {
     setSetupError(null);


### PR DESCRIPTION
When no stacks exist yet, Create Stack falls back to the hardcoded /etc/docker/compose suggestion regardless of runtime mode. Default to the current user's home directory instead when running rootless Docker/Podman, since /etc is typically not writable there.

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [ ] Manually tested in Cockpit (if UI change)
