### PR TITLE
feat: add run-in-background option for Up and Pull (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ The UI language follows Cockpit's language setting.
 | Coverage | Languages |
 |---|---|
 | 100% | English (`en`) — source |
-| 97% | `de`, `pl` |
-| 95% | `ar`, `cs`, `es`, `fi`, `fr`, `he`, `id`, `it`, `ja`, `ka`, `ko`, `nl`, `pt-BR`, `ro`, `ru`, `sk`, `sv`, `tr`, `uk`, `zh-CN`, `zh-TW` |
+| 94% | `de`, `pl` |
+| 92% | `ar`, `cs`, `es`, `fi`, `fr`, `he`, `id`, `it`, `ja`, `ka`, `ko`, `nl`, `pt-BR`, `ro`, `ru`, `sk`, `sv`, `tr`, `uk`, `zh-CN`, `zh-TW` |
 <!-- i18n-coverage-end -->
 
 To add a new language, copy `src/i18n/locales/en.json`, translate the values, and register the file in `src/i18n/index.ts`.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,6 +6,8 @@ import { AppFooter } from "./AppFooter";
 import { StacksView } from "./StacksView";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { ToastProvider } from "./ToastProvider";
+import { BackgroundTasksProvider } from "../hooks/useBackgroundTasks";
+import { BackgroundTasksDrawer } from "./BackgroundTasksDrawer";
 import { detectComposeCommand, detectDockerMode, type Runtime } from "../api";
 import { type Layout, LAYOUT_KEY } from "../lib/layout";
 import "./layouts.css";
@@ -36,21 +38,24 @@ export function App() {
 
   return (
     <ToastProvider>
-      <div data-layout={layout}>
-        <Page className="pf-m-no-sidebar">
-          <PageSection hasBodyWrapper={false} isFilled>
-            <ErrorBoundary fallbackTitle={t("error_boundary.load_stacks_error")}>
-              <StacksView
-                onRuntimeChange={setRuntime}
-                dockerMissing={dockerMissing}
-                layout={layout}
-                onLayoutChange={setLayout}
-              />
-            </ErrorBoundary>
-          </PageSection>
-          <AppFooter runtime={runtime} />
-        </Page>
-      </div>
+      <BackgroundTasksProvider>
+        <div data-layout={layout}>
+          <Page className="pf-m-no-sidebar">
+            <PageSection hasBodyWrapper={false} isFilled>
+              <ErrorBoundary fallbackTitle={t("error_boundary.load_stacks_error")}>
+                <StacksView
+                  onRuntimeChange={setRuntime}
+                  dockerMissing={dockerMissing}
+                  layout={layout}
+                  onLayoutChange={setLayout}
+                />
+              </ErrorBoundary>
+            </PageSection>
+            <AppFooter runtime={runtime} />
+          </Page>
+          <BackgroundTasksDrawer />
+        </div>
+      </BackgroundTasksProvider>
     </ToastProvider>
   );
 }

--- a/src/components/BackgroundTaskLogModal.test.tsx
+++ b/src/components/BackgroundTaskLogModal.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BackgroundTaskLogModal } from "./BackgroundTaskLogModal";
+import type { BackgroundTask } from "../hooks/useBackgroundTasks";
+
+const mockStop = vi.fn();
+vi.mock("../hooks/useBackgroundTasks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../hooks/useBackgroundTasks")>();
+  return { ...actual, useBackgroundTasks: () => ({ tasks: [], enqueue: vi.fn(), stop: mockStop, remove: vi.fn() }) };
+});
+
+const runningTask: BackgroundTask = {
+  id: 1, stackName: "myapp", action: "up", label: "Up — myapp", status: "running", lines: ["line one"], createdAt: 0,
+};
+
+describe("BackgroundTaskLogModal", () => {
+  it("renders the task label as the modal title and its lines", () => {
+    render(<BackgroundTaskLogModal task={runningTask} onClose={vi.fn()} />);
+    expect(screen.getByText("Up — myapp")).toBeInTheDocument();
+    expect(screen.getByText("line one")).toBeInTheDocument();
+  });
+
+  it("shows a Stop button while running, which calls stop()", () => {
+    render(<BackgroundTaskLogModal task={runningTask} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /^Stop$/i }));
+    expect(mockStop).toHaveBeenCalledWith(1);
+  });
+
+  it("shows a Close button (not Stop) once finished", () => {
+    const onClose = vi.fn();
+    render(<BackgroundTaskLogModal task={{ ...runningTask, status: "success" }} onClose={onClose} />);
+    expect(screen.queryByRole("button", { name: /^Stop$/i })).not.toBeInTheDocument();
+    const closeButtons = screen.getAllByRole("button", { name: /Close/i });
+    fireEvent.click(closeButtons[closeButtons.length - 1]);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows the error message when the task failed", () => {
+    render(<BackgroundTaskLogModal task={{ ...runningTask, status: "error", errorMsg: "boom" }} onClose={vi.fn()} />);
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+});

--- a/src/components/BackgroundTaskLogModal.tsx
+++ b/src/components/BackgroundTaskLogModal.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from "react-i18next";
+import { Modal, ModalHeader, ModalBody, Button } from "@patternfly/react-core";
+import { LogViewer } from "@rxtx4816/cockpit-plugin-base-react/components";
+import { useBackgroundTasks, type BackgroundTask } from "../hooks/useBackgroundTasks";
+
+interface Props {
+  task: BackgroundTask;
+  onClose: () => void;
+}
+
+export function BackgroundTaskLogModal({ task, onClose }: Props) {
+  const { t } = useTranslation();
+  const { stop } = useBackgroundTasks();
+  const running = task.status === "running" || task.status === "pending";
+
+  return (
+    <Modal isOpen onClose={onClose} variant="medium" aria-label={task.label}>
+      <ModalHeader title={task.label} />
+      <ModalBody>
+        <LogViewer
+          lines={task.lines}
+          error={task.status === "error" ? task.errorMsg : null}
+          emptyMessage={t("background_tasks.log_empty")}
+        />
+        <div className="btd-log-footer">
+          {running
+            ? <Button variant="danger" onClick={() => stop(task.id)}>{t("background_tasks.stop_button")}</Button>
+            : <Button variant="primary" onClick={onClose}>{t("common.close")}</Button>
+          }
+        </div>
+      </ModalBody>
+    </Modal>
+  );
+}

--- a/src/components/BackgroundTasksDrawer.css
+++ b/src/components/BackgroundTasksDrawer.css
@@ -1,0 +1,62 @@
+.btd-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: var(--pf-t--global--z-index--xl, 500);
+  background: var(--pf-t--global--background--color--primary--default);
+  border-radius: 999px;
+  box-shadow: var(--pf-t--global--box-shadow--md);
+}
+
+.btd-toggle-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(35%, -35%);
+}
+
+.btd-panel {
+  position: fixed;
+  bottom: 4.25rem;
+  right: 1rem;
+  width: min(380px, calc(100vw - 2rem));
+  max-height: 50vh;
+  z-index: var(--pf-t--global--z-index--xl, 500);
+  box-shadow: var(--pf-t--global--box-shadow--lg);
+  border-radius: var(--pf-t--global--border--radius--200, 8px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.btd-body {
+  overflow-y: auto;
+}
+
+.btd-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.btd-item-status {
+  font-size: 0.8125rem;
+  color: var(--pf-t--global--text--color--subtle);
+  text-transform: capitalize;
+}
+
+.btd-item-error {
+  font-size: 0.8125rem;
+  color: var(--pf-t--global--text--color--status--danger--default, #f85149);
+}
+
+.btd-item-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btd-log-footer {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/components/BackgroundTasksDrawer.test.tsx
+++ b/src/components/BackgroundTasksDrawer.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BackgroundTasksDrawer } from "./BackgroundTasksDrawer";
+import type { BackgroundTask } from "../hooks/useBackgroundTasks";
+
+const mockStop = vi.fn();
+const mockRemove = vi.fn();
+let mockTasks: BackgroundTask[] = [];
+
+vi.mock("../hooks/useBackgroundTasks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../hooks/useBackgroundTasks")>();
+  return {
+    ...actual,
+    useBackgroundTasks: () => ({ tasks: mockTasks, enqueue: vi.fn(), stop: mockStop, remove: mockRemove }),
+  };
+});
+
+beforeEach(() => {
+  mockTasks = [];
+  mockStop.mockReset();
+  mockRemove.mockReset();
+});
+
+describe("BackgroundTasksDrawer", () => {
+  it("renders a toggle button with no badge when there are no active tasks", () => {
+    render(<BackgroundTasksDrawer />);
+    expect(screen.getByRole("button", { name: /Background tasks/i })).toBeInTheDocument();
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+  });
+
+  it("shows a badge count of pending/running tasks", () => {
+    mockTasks = [
+      { id: 1, stackName: "a", action: "up", label: "Up a", status: "running", lines: [], createdAt: 0 },
+      { id: 2, stackName: "b", action: "pull", label: "Pull b", status: "pending", lines: [], createdAt: 0 },
+      { id: 3, stackName: "c", action: "up", label: "Up c", status: "success", lines: [], createdAt: 0 },
+    ];
+    render(<BackgroundTasksDrawer />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("panel is closed by default and opens on toggle click", () => {
+    mockTasks = [{ id: 1, stackName: "a", action: "up", label: "Up a", status: "running", lines: [], createdAt: 0 }];
+    render(<BackgroundTasksDrawer />);
+    expect(screen.queryByText("Up a")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    expect(screen.getByText("Up a")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no tasks", () => {
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    expect(screen.getByText(/No background tasks/i)).toBeInTheDocument();
+  });
+
+  it("shows a Stop button for a running task and calls stop() on click", () => {
+    mockTasks = [{ id: 1, stackName: "a", action: "up", label: "Up a", status: "running", lines: [], createdAt: 0 }];
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Stop$/i }));
+    expect(mockStop).toHaveBeenCalledWith(1);
+  });
+
+  it("shows a Remove button (not Stop) for a finished task and calls remove() on click", () => {
+    mockTasks = [{ id: 2, stackName: "b", action: "pull", label: "Pull b", status: "success", lines: [], createdAt: 0 }];
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    expect(screen.queryByRole("button", { name: /^Stop$/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^Remove$/i }));
+    expect(mockRemove).toHaveBeenCalledWith(2);
+  });
+
+  it("shows the error message for a failed task", () => {
+    mockTasks = [{
+      id: 3, stackName: "c", action: "up", label: "Up c", status: "error", errorMsg: "boom", lines: [], createdAt: 0,
+    }];
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("clicking a running task's row reopens its log modal", () => {
+    mockTasks = [{
+      id: 1, stackName: "a", action: "up", label: "Up a", status: "running",
+      lines: ["Container a-web-1  Starting"], createdAt: 0,
+    }];
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    fireEvent.click(screen.getByText("Up a"));
+    expect(screen.getByText(/Container a-web-1/)).toBeInTheDocument();
+  });
+
+  it("clicking Stop on a running row does not also reopen its log modal", () => {
+    mockTasks = [{ id: 1, stackName: "a", action: "up", label: "Up a", status: "running", lines: [], createdAt: 0 }];
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Stop$/i }));
+    expect(mockStop).toHaveBeenCalledWith(1);
+    expect(screen.queryByText(/Waiting for output/i)).not.toBeInTheDocument();
+  });
+
+  it("clicking a finished task's row does not reopen a modal", () => {
+    mockTasks = [{ id: 2, stackName: "b", action: "pull", label: "Pull b", status: "success", lines: [], createdAt: 0 }];
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    fireEvent.click(screen.getByText("Pull b"));
+    expect(screen.queryByText(/Waiting for output/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/BackgroundTasksDrawer.tsx
+++ b/src/components/BackgroundTasksDrawer.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  Badge,
+  NotificationDrawer,
+  NotificationDrawerBody,
+  NotificationDrawerHeader,
+  NotificationDrawerList,
+  NotificationDrawerListItem,
+  NotificationDrawerListItemHeader,
+  NotificationDrawerListItemBody,
+  EmptyState,
+  EmptyStateBody,
+} from "@patternfly/react-core";
+import { ListIcon } from "@patternfly/react-icons";
+import { useBackgroundTasks, type BackgroundTask, type BackgroundTaskStatus } from "../hooks/useBackgroundTasks";
+import { BackgroundTaskLogModal } from "./BackgroundTaskLogModal";
+import "./BackgroundTasksDrawer.css";
+
+function statusVariant(status: BackgroundTaskStatus): "success" | "danger" | "warning" | "info" | "custom" {
+  switch (status) {
+    case "success": return "success";
+    case "error": return "danger";
+    case "stopped": return "warning";
+    default: return "info";
+  }
+}
+
+export function BackgroundTasksDrawer() {
+  const { t } = useTranslation();
+  const { tasks, stop, remove } = useBackgroundTasks();
+  const [open, setOpen] = useState(false);
+  const [openTask, setOpenTask] = useState<BackgroundTask | null>(null);
+
+  const activeCount = tasks.filter(t => t.status === "pending" || t.status === "running").length;
+  // Reflects live status/lines of the task currently shown in the log modal, if still tracked.
+  const liveOpenTask = openTask ? tasks.find(t => t.id === openTask.id) ?? openTask : null;
+
+  return (
+    <>
+      <Button
+        variant="plain"
+        className="btd-toggle"
+        aria-label={t("background_tasks.toggle_button")}
+        onClick={() => setOpen(o => !o)}
+      >
+        <ListIcon />
+        {activeCount > 0 && <Badge className="btd-toggle-badge">{activeCount}</Badge>}
+      </Button>
+
+      {open && (
+        <div className="btd-panel">
+          <NotificationDrawer>
+            <NotificationDrawerHeader
+              title={t("background_tasks.title")}
+              count={tasks.length}
+              onClose={() => setOpen(false)}
+            />
+            <NotificationDrawerBody className="btd-body">
+              {tasks.length === 0 ? (
+                <EmptyState titleText={t("background_tasks.empty_title")} headingLevel="h4">
+                  <EmptyStateBody>{t("background_tasks.empty_body")}</EmptyStateBody>
+                </EmptyState>
+              ) : (
+                <NotificationDrawerList>
+                  {tasks.map(task => {
+                    const clickable = task.status === "running" || task.status === "pending";
+                    return (
+                      <NotificationDrawerListItem
+                        key={task.id}
+                        variant={statusVariant(task.status)}
+                        isHoverable={clickable}
+                        onClick={clickable ? () => setOpenTask(task) : undefined}
+                      >
+                        <NotificationDrawerListItemHeader
+                          variant={statusVariant(task.status)}
+                          title={task.label}
+                        />
+                        <NotificationDrawerListItemBody>
+                          <div className="btd-item-body">
+                            <span className="btd-item-status">{t(`background_tasks.status_${task.status}`)}</span>
+                            {task.errorMsg && <span className="btd-item-error">{task.errorMsg}</span>}
+                            <div className="btd-item-actions">
+                              {task.status === "running" && (
+                                <Button
+                                  variant="danger"
+                                  size="sm"
+                                  onClick={(e) => { e.stopPropagation(); stop(task.id); }}
+                                >
+                                  {t("background_tasks.stop_button")}
+                                </Button>
+                              )}
+                              {task.status !== "running" && (
+                                <Button
+                                  variant="secondary"
+                                  size="sm"
+                                  onClick={(e) => { e.stopPropagation(); remove(task.id); }}
+                                >
+                                  {t("background_tasks.remove_button")}
+                                </Button>
+                              )}
+                            </div>
+                          </div>
+                        </NotificationDrawerListItemBody>
+                      </NotificationDrawerListItem>
+                    );
+                  })}
+                </NotificationDrawerList>
+              )}
+            </NotificationDrawerBody>
+          </NotificationDrawer>
+        </div>
+      )}
+
+      {liveOpenTask && <BackgroundTaskLogModal task={liveOpenTask} onClose={() => setOpenTask(null)} />}
+    </>
+  );
+}

--- a/src/components/PullModal.test.tsx
+++ b/src/components/PullModal.test.tsx
@@ -7,6 +7,11 @@ vi.mock("../hooks/usePullStream", () => ({
   usePullStream: vi.fn(),
 }));
 
+const mockEnqueue = vi.fn();
+vi.mock("../hooks/useBackgroundTasks", () => ({
+  useBackgroundTasks: () => ({ enqueue: mockEnqueue, tasks: [], stop: vi.fn(), remove: vi.fn() }),
+}));
+
 import { usePullStream } from "../hooks/usePullStream";
 const mockUsePullStream = vi.mocked(usePullStream);
 
@@ -24,6 +29,7 @@ beforeEach(() => {
     errorMsg: "",
     cancel: vi.fn(),
   });
+  mockEnqueue.mockReset();
 });
 
 describe("PullModal", () => {
@@ -103,5 +109,27 @@ describe("PullModal", () => {
     mockUsePullStream.mockReturnValue({ lines: [], done: false, failed: false, errorMsg: "", cancel: vi.fn() });
     render(<PullModal stack={multiStack} onClose={vi.fn()} />);
     expect(mockUsePullStream).toHaveBeenCalledWith("myapp", ["/a.yml", "/b.yml"]);
+  });
+
+  it("shows Run in Background button while not done", () => {
+    render(<PullModal stack={stack} onClose={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /Run in Background/i })).toBeInTheDocument();
+  });
+
+  it("does not show Run in Background button when done", () => {
+    mockUsePullStream.mockReturnValue({ lines: [], done: true, failed: false, errorMsg: "", cancel: vi.fn() });
+    render(<PullModal stack={stack} onClose={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /Run in Background/i })).not.toBeInTheDocument();
+  });
+
+  it("clicking Run in Background cancels the foreground stream, enqueues a task, and closes", () => {
+    const cancel = vi.fn();
+    const onClose = vi.fn();
+    mockUsePullStream.mockReturnValue({ lines: [], done: false, failed: false, errorMsg: "", cancel });
+    render(<PullModal stack={stack} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /Run in Background/i }));
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(mockEnqueue).toHaveBeenCalledWith("myapp", "pull", expect.stringContaining("myapp"), expect.any(Function));
+    expect(onClose).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/PullModal.tsx
+++ b/src/components/PullModal.tsx
@@ -7,8 +7,9 @@ import {
   Spinner,
 } from "@patternfly/react-core";
 import { LogViewer } from "@rxtx4816/cockpit-plugin-base-react/components";
-import { type ComposeStack } from "../api";
+import { type ComposeStack, pullStack, composeFileSuperuser, isRootlessMode, readAllProfiles } from "../api";
 import { usePullStream } from "../hooks/usePullStream";
+import { useBackgroundTasks } from "../hooks/useBackgroundTasks";
 import "./PullModal.css";
 import { splitConfigFiles } from "../lib/configFiles";
 
@@ -21,9 +22,21 @@ export function PullModal({ stack, onClose }: Props) {
   const { t } = useTranslation();
   const configFiles = splitConfigFiles(stack.ConfigFiles);
   const { lines, done, failed, errorMsg, cancel } = usePullStream(stack.Name, configFiles);
+  const { enqueue } = useBackgroundTasks();
 
   const handleClose = () => {
     cancel();
+    onClose();
+  };
+
+  const handleBackground = () => {
+    cancel();
+    enqueue(stack.Name, "pull", t("pull_modal.background_label", { name: stack.Name }), launch => {
+      return Promise.all([
+        isRootlessMode() ? Promise.resolve(undefined) : composeFileSuperuser(configFiles),
+        readAllProfiles(configFiles[0]),
+      ]).then(([su, profiles]) => { launch(pullStack(stack.Name, configFiles, profiles, su)); });
+    });
     onClose();
   };
 
@@ -46,7 +59,12 @@ export function PullModal({ stack, onClose }: Props) {
 
         <div className="pm-footer">
           {!done
-            ? <Button variant="secondary" onClick={handleClose}>{t("common.cancel")}</Button>
+            ? (
+              <>
+                <Button variant="secondary" onClick={handleBackground}>{t("pull_modal.background_button")}</Button>
+                <Button variant="secondary" onClick={handleClose}>{t("common.cancel")}</Button>
+              </>
+            )
             : <Button variant="primary" onClick={handleClose}>{t("common.close")}</Button>
           }
         </div>

--- a/src/components/UpModal.test.tsx
+++ b/src/components/UpModal.test.tsx
@@ -7,6 +7,11 @@ vi.mock("../hooks/useUpStream", () => ({
   useUpStream: vi.fn(),
 }));
 
+const mockEnqueue = vi.fn();
+vi.mock("../hooks/useBackgroundTasks", () => ({
+  useBackgroundTasks: () => ({ enqueue: mockEnqueue, tasks: [], stop: vi.fn(), remove: vi.fn() }),
+}));
+
 import { useUpStream } from "../hooks/useUpStream";
 const mockUseUpStream = vi.mocked(useUpStream);
 
@@ -24,6 +29,7 @@ beforeEach(() => {
     errorMsg: "",
     cancel: vi.fn(),
   });
+  mockEnqueue.mockReset();
 });
 
 describe("UpModal", () => {
@@ -128,5 +134,27 @@ describe("UpModal", () => {
     mockUseUpStream.mockReturnValue({ lines: [], done: false, failed: false, errorMsg: "", cancel: vi.fn() });
     render(<UpModal stack={stack} profiles={["dev", "debug"]} onClose={vi.fn()} />);
     expect(mockUseUpStream).toHaveBeenCalledWith("myapp", ["/path/compose.yml"], ["dev", "debug"]);
+  });
+
+  it("shows Run in Background button while not done", () => {
+    render(<UpModal stack={stack} onClose={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /Run in Background/i })).toBeInTheDocument();
+  });
+
+  it("does not show Run in Background button when done", () => {
+    mockUseUpStream.mockReturnValue({ lines: [], done: true, failed: false, errorMsg: "", cancel: vi.fn() });
+    render(<UpModal stack={stack} onClose={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /Run in Background/i })).not.toBeInTheDocument();
+  });
+
+  it("clicking Run in Background cancels the foreground stream, enqueues a task, and closes with success", () => {
+    const cancel = vi.fn();
+    const onClose = vi.fn();
+    mockUseUpStream.mockReturnValue({ lines: [], done: false, failed: false, errorMsg: "", cancel });
+    render(<UpModal stack={stack} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /Run in Background/i }));
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(mockEnqueue).toHaveBeenCalledWith("myapp", "up", expect.stringContaining("myapp"), expect.any(Function));
+    expect(onClose).toHaveBeenCalledWith(true);
   });
 });

--- a/src/components/UpModal.tsx
+++ b/src/components/UpModal.tsx
@@ -7,8 +7,9 @@ import {
   Spinner,
 } from "@patternfly/react-core";
 import { LogViewer } from "@rxtx4816/cockpit-plugin-base-react/components";
-import { type ComposeStack } from "../api";
+import { type ComposeStack, upStackStream, composeFileSuperuser, isRootlessMode } from "../api";
 import { useUpStream } from "../hooks/useUpStream";
+import { useBackgroundTasks } from "../hooks/useBackgroundTasks";
 import "./UpModal.css";
 import { splitConfigFiles } from "../lib/configFiles";
 
@@ -22,10 +23,20 @@ export function UpModal({ stack, profiles = [], onClose }: Props) {
   const { t } = useTranslation();
   const configFiles = splitConfigFiles(stack.ConfigFiles);
   const { lines, done, failed, errorMsg, cancel } = useUpStream(stack.Name, configFiles, profiles);
+  const { enqueue } = useBackgroundTasks();
 
   const handleClose = () => {
     cancel();
     onClose(done && !failed);
+  };
+
+  const handleBackground = () => {
+    cancel();
+    enqueue(stack.Name, "up", t("up_modal.background_label", { name: stack.Name }), launch => {
+      const suPromise = isRootlessMode() ? Promise.resolve(undefined) : composeFileSuperuser(configFiles);
+      return suPromise.then(su => { launch(upStackStream(stack.Name, configFiles, profiles, su)); });
+    });
+    onClose(true);
   };
 
   return (
@@ -47,7 +58,12 @@ export function UpModal({ stack, profiles = [], onClose }: Props) {
 
         <div className="um-footer">
           {!done
-            ? <Button variant="secondary" onClick={handleClose}>{t("common.cancel")}</Button>
+            ? (
+              <>
+                <Button variant="secondary" onClick={handleBackground}>{t("up_modal.background_button")}</Button>
+                <Button variant="secondary" onClick={handleClose}>{t("common.cancel")}</Button>
+              </>
+            )
             : <Button variant="primary" onClick={handleClose}>{t("common.close")}</Button>
           }
         </div>

--- a/src/hooks/useBackgroundTasks.test.tsx
+++ b/src/hooks/useBackgroundTasks.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { BackgroundTasksProvider, useBackgroundTasks } from "./useBackgroundTasks";
+import type { ReactNode } from "react";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <BackgroundTasksProvider>{children}</BackgroundTasksProvider>;
+}
+
+function fakeProcess(behavior: "resolve" | "reject" = "resolve"): CockpitProcess {
+  let resolveFn: (() => void) | undefined;
+  let rejectFn: ((err: Error) => void) | undefined;
+  const p = new Promise<string>((resolve, reject) => {
+    resolveFn = () => resolve("");
+    rejectFn = reject;
+  });
+  const close = vi.fn(() => rejectFn?.(new Error("terminated")));
+  if (behavior === "resolve") queueMicrotask(() => resolveFn?.());
+  if (behavior === "reject") queueMicrotask(() => rejectFn?.(new Error("boom")));
+  return Object.assign(p, {
+    stream: () => p as CockpitProcess,
+    close,
+    input: vi.fn(),
+    wait: () => p,
+  }) as unknown as CockpitProcess;
+}
+
+describe("useBackgroundTasks", () => {
+  it("starts empty and the noop fallback outside a provider is safe to call", () => {
+    const { result } = renderHook(() => useBackgroundTasks());
+    expect(result.current.tasks).toEqual([]);
+    expect(() => result.current.enqueue("a", "up", "Up a", launch => launch(fakeProcess()))).not.toThrow();
+  });
+
+  it("enqueue adds a pending task, which transitions to running then success", async () => {
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    const start = vi.fn((launch: (p: CockpitProcess) => void) => launch(fakeProcess("resolve")));
+
+    act(() => { result.current.enqueue("myapp", "up", "Up myapp", start); });
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0].status).toBe("running");
+
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("success"));
+    expect(start).toHaveBeenCalledOnce();
+  });
+
+  it("a failed task ends in 'error' status with the error message", async () => {
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    act(() => { result.current.enqueue("myapp", "up", "Up myapp", launch => launch(fakeProcess("reject"))); });
+
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("error"));
+    expect(result.current.tasks[0].errorMsg).toBe("boom");
+  });
+
+  it("runs tasks one at a time (single runner)", async () => {
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    const proc1 = fakeProcess("resolve");
+    const proc2 = fakeProcess("resolve");
+    const start1 = vi.fn((launch: (p: CockpitProcess) => void) => launch(proc1));
+    const start2 = vi.fn((launch: (p: CockpitProcess) => void) => launch(proc2));
+
+    act(() => {
+      result.current.enqueue("a", "up", "Up a", start1);
+      result.current.enqueue("b", "up", "Up b", start2);
+    });
+
+    expect(result.current.tasks[0].status).toBe("running");
+    expect(result.current.tasks[1].status).toBe("pending");
+    expect(start2).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("success"));
+    await waitFor(() => expect(result.current.tasks[1].status).not.toBe("pending"));
+    expect(start2).toHaveBeenCalledOnce();
+  });
+
+  it("stop() marks the task 'stopped' once its process settles, and closes the process", async () => {
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    const proc = fakeProcess("reject");
+    const start = vi.fn((launch: (p: CockpitProcess) => void) => launch(proc));
+
+    act(() => { result.current.enqueue("myapp", "up", "Up myapp", start); });
+    const id = result.current.tasks[0].id;
+    act(() => { result.current.stop(id); });
+
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("stopped"));
+    expect(proc.close).toHaveBeenCalled();
+  });
+
+  it("remove() removes a finished task, but not a running one", async () => {
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    act(() => { result.current.enqueue("myapp", "up", "Up myapp", launch => launch(fakeProcess("resolve"))); });
+    const id = result.current.tasks[0].id;
+
+    act(() => { result.current.remove(id); });
+    expect(result.current.tasks).toHaveLength(1); // still running, remove is a no-op
+
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("success"));
+    act(() => { result.current.remove(id); });
+    expect(result.current.tasks).toHaveLength(0);
+  });
+
+  it("a starter whose setup work rejects before calling launch ends in 'error', not stuck at 'running' forever", async () => {
+    // Regression test: e.g. readAllProfiles()/composeFileSuperuser() throwing before launch()
+    // is ever called must not leave the task permanently stuck at "running".
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    const start = vi.fn(() => Promise.reject(new Error("setup failed")));
+
+    act(() => { result.current.enqueue("myapp", "pull", "Pull myapp", start); });
+    expect(result.current.tasks[0].status).toBe("running");
+
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("error"));
+    expect(result.current.tasks[0].errorMsg).toBe("setup failed");
+  });
+
+  it("accumulates streamed output into task.lines", async () => {
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    let streamCb: ((data: string) => void) | undefined;
+    const proc = fakeProcess("resolve");
+    proc.stream = (cb: (data: string) => void) => { streamCb = cb; return proc; };
+
+    act(() => { result.current.enqueue("myapp", "up", "Up myapp", launch => launch(proc)); });
+    act(() => { streamCb?.("Container myapp-web-1  Starting\n"); });
+
+    await waitFor(() => expect(result.current.tasks[0].lines).toEqual(["Container myapp-web-1  Starting"]));
+  });
+
+  it("enqueueing a pending (not-yet-started) task and removing it never invokes its starter", () => {
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    const start1 = vi.fn((launch: (p: CockpitProcess) => void) => launch(fakeProcess("resolve")));
+    const start2 = vi.fn();
+
+    act(() => {
+      result.current.enqueue("a", "up", "Up a", start1); // occupies the single runner slot
+      result.current.enqueue("b", "up", "Up b", start2); // stays pending
+    });
+    const pendingId = result.current.tasks[1].id;
+    act(() => { result.current.remove(pendingId); });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(start2).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useBackgroundTasks.tsx
+++ b/src/hooks/useBackgroundTasks.tsx
@@ -1,0 +1,151 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import { stripAnsi } from "../lib/pullParser";
+
+export type BackgroundTaskStatus = "pending" | "running" | "success" | "error" | "stopped";
+
+export interface BackgroundTask {
+  id: number;
+  stackName: string;
+  action: string;
+  label: string;
+  status: BackgroundTaskStatus;
+  errorMsg?: string;
+  lines: string[];
+  createdAt: number;
+}
+
+// Mirrors the `launch` callback pattern used by useAsyncStream: the starter is
+// handed a `launch` function to call once it has produced the CockpitProcess
+// (e.g. after resolving superuser). This is deliberate rather than simply
+// returning/awaiting the process, since CockpitProcess is itself thenable —
+// `Promise.resolve()`-ing it (or returning it from an async function) would
+// silently flatten to its *resolved value*, not the process handle.
+//
+// The starter may return a Promise (its own setup work, e.g. resolving
+// superuser) — if that promise rejects *before* `launch` is ever called, the
+// task is reported as failed. Without this, a setup failure would otherwise
+// leave the task stuck at "running" forever, since nothing would ever settle it.
+type TaskStarter = (launch: (proc: CockpitProcess) => void) => void | Promise<void>;
+
+export interface BackgroundTasksContextValue {
+  tasks: BackgroundTask[];
+  /** Enqueues a task. `start` is only invoked once the task reaches the front of the queue. */
+  enqueue: (stackName: string, action: string, label: string, start: TaskStarter) => void;
+  /** Closes the underlying process of a running task (or marks a not-yet-started one to stop as soon as it starts). */
+  stop: (id: number) => void;
+  /** Removes a task from the list. No-op while the task is still running. */
+  remove: (id: number) => void;
+}
+
+const BackgroundTasksContext = createContext<BackgroundTasksContextValue | null>(null);
+
+const NOOP_BACKGROUND_TASKS: BackgroundTasksContextValue = {
+  tasks: [],
+  enqueue: () => {},
+  stop: () => {},
+  remove: () => {},
+};
+
+/**
+ * Provides a single-runner FIFO background task queue to the component tree.
+ *
+ * Tasks are enqueued as a `start` factory rather than an already-spawned
+ * process, so a task removed while still pending never touches `cockpit.spawn`.
+ * Only one task runs at a time to avoid concurrent side effects on the same stacks.
+ */
+export function BackgroundTasksProvider({ children }: { children: ReactNode }) {
+  const [tasks, setTasks] = useState<BackgroundTask[]>([]);
+  const countersRef = useRef(0);
+  const startersRef = useRef(new Map<number, TaskStarter>());
+  const procsRef = useRef(new Map<number, CockpitProcess>());
+  const stoppedRef = useRef(new Set<number>());
+  const bufsRef = useRef(new Map<number, string>());
+  const runningRef = useRef(false);
+  const settledRef = useRef(new Set<number>());
+
+  // Picks the next pending task once the previous one finishes (or on enqueue).
+  // Re-fires whenever `tasks` changes, including the status updates this same
+  // effect makes — that's what lets it chain through the whole queue.
+  useEffect(() => {
+    if (runningRef.current) return;
+    const next = tasks.find(t => t.status === "pending");
+    if (!next) return;
+
+    runningRef.current = true;
+    setTasks(prev => prev.map(t => (t.id === next.id ? { ...t, status: "running" } : t)));
+
+    const starter = startersRef.current.get(next.id);
+    const finish = (status: "success" | "error" | "stopped", errorMsg?: string) => {
+      if (settledRef.current.has(next.id)) return;
+      settledRef.current.add(next.id);
+      setTasks(prev => prev.map(t => (t.id === next.id ? { ...t, status, errorMsg } : t)));
+      procsRef.current.delete(next.id);
+      startersRef.current.delete(next.id);
+      stoppedRef.current.delete(next.id);
+      bufsRef.current.delete(next.id);
+      settledRef.current.delete(next.id);
+      runningRef.current = false;
+    };
+
+    const appendLine = (chunk: string) => {
+      const clean = stripAnsi(chunk);
+      const buffered = (bufsRef.current.get(next.id) ?? "") + clean;
+      const parts = buffered.split("\n");
+      bufsRef.current.set(next.id, parts.pop() ?? "");
+      const newLines = parts.map(l => l.split("\r").pop() ?? "").filter(l => l.trim() !== "");
+      if (newLines.length > 0) {
+        setTasks(prev => prev.map(t => (t.id === next.id ? { ...t, lines: [...t.lines, ...newLines] } : t)));
+      }
+    };
+
+    const setupResult = starter?.(proc => {
+      procsRef.current.set(next.id, proc);
+      if (stoppedRef.current.has(next.id)) { proc.close(); return; }
+      proc.stream(appendLine);
+      proc
+        .then(() => finish(stoppedRef.current.has(next.id) ? "stopped" : "success"))
+        .catch((ex: unknown) => finish(
+          stoppedRef.current.has(next.id) ? "stopped" : "error",
+          ex instanceof Error ? ex.message : String(ex),
+        ));
+    });
+
+    // If the starter's own setup work (before `launch` is called) rejects,
+    // the task must still be settled — otherwise it's stuck at "running" forever.
+    if (setupResult && typeof setupResult.then === "function") {
+      setupResult.catch((ex: unknown) => finish("error", ex instanceof Error ? ex.message : String(ex)));
+    }
+  }, [tasks]);
+
+  const enqueue = useCallback((stackName: string, action: string, label: string, start: TaskStarter) => {
+    const id = ++countersRef.current;
+    startersRef.current.set(id, start);
+    setTasks(prev => [...prev, { id, stackName, action, label, status: "pending", lines: [], createdAt: Date.now() }]);
+  }, []);
+
+  const stop = useCallback((id: number) => {
+    stoppedRef.current.add(id);
+    procsRef.current.get(id)?.close();
+  }, []);
+
+  const remove = useCallback((id: number) => {
+    setTasks(prev => prev.filter(t => !(t.id === id && t.status !== "running")));
+    startersRef.current.delete(id);
+  }, []);
+
+  return (
+    <BackgroundTasksContext.Provider value={{ tasks, enqueue, stop, remove }}>
+      {children}
+    </BackgroundTasksContext.Provider>
+  );
+}
+
+/**
+ * Returns the nearest {@link BackgroundTasksProvider}'s context value.
+ *
+ * Falls back to a no-op implementation when called outside a provider, so
+ * it is safe to use in unit tests without a provider wrapper.
+ */
+export function useBackgroundTasks(): BackgroundTasksContextValue {
+  return useContext(BackgroundTasksContext) ?? NOOP_BACKGROUND_TASKS;
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -383,7 +383,9 @@
     "pulling": "Pulling images for {{name}}…",
     "complete": "✓ Pull complete",
     "failed": "✗ Pull failed",
-    "starting": "Starting pull…"
+    "starting": "Starting pull…",
+    "background_button": "Run in Background",
+    "background_label": "Pull — {{name}}"
   },
   "pull_confirm_modal": {
     "aria_label": "Confirm pull — {{name}}",
@@ -402,7 +404,9 @@
     "starting": "Starting {{name}}…",
     "initializing": "Starting…",
     "complete": "✓ Up complete",
-    "failed": "✗ Up failed"
+    "failed": "✗ Up failed",
+    "background_button": "Run in Background",
+    "background_label": "Up — {{name}}"
   },
   "up_confirm_modal": {
     "aria_label": "Confirm up — {{name}}",
@@ -618,5 +622,19 @@
     "port_conflict_title": "Port conflict likely",
     "port_conflict_body": "The following services have static host port bindings. Docker will not be able to start more than one replica because a host port can only be bound by a single container:",
     "port_conflict_icon_title": "Has static host port bindings"
+  },
+  "background_tasks": {
+    "toggle_button": "Background tasks",
+    "title": "Background tasks",
+    "empty_title": "No background tasks",
+    "empty_body": "Tasks sent to the background will show up here.",
+    "status_pending": "Pending",
+    "status_running": "Running",
+    "status_success": "Complete",
+    "status_error": "Failed",
+    "status_stopped": "Stopped",
+    "stop_button": "Stop",
+    "remove_button": "Remove",
+    "log_empty": "Waiting for output…"
   }
 }


### PR DESCRIPTION
Long-running actions currently block the UI in a modal with a spinner until they finish. Add a single-runner FIFO background task queue (useBackgroundTasks) plus a floating drawer to view, stop, or remove tasks. Up and Pull modals gain a "Run in Background" button that cancels the foreground stream and re-launches the same action as a tracked background task instead.

Streamed output is accumulated per task so a running task's log can be reopened from the drawer at any time. Setup failures (e.g. resolving superuser or reading profiles) are now caught and reported as a failed task instead of leaving it stuck at "running" forever.

Scoped to Up and Pull for now, since those are the two modal-driven streaming actions; Down and the simpler start/stop/restart actions can be wired into the same queue later.
closes #185 

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
