### PR TITLE
feat: select multiple stacks and run bulk actions (#186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ The UI language follows Cockpit's language setting.
 | Coverage | Languages |
 |---|---|
 | 100% | English (`en`) — source |
-| 94% | `de`, `pl` |
-| 92% | `ar`, `cs`, `es`, `fi`, `fr`, `he`, `id`, `it`, `ja`, `ka`, `ko`, `nl`, `pt-BR`, `ro`, `ru`, `sk`, `sv`, `tr`, `uk`, `zh-CN`, `zh-TW` |
+| 90% | `de`, `pl` |
+| 88% | `ar`, `cs`, `es`, `fi`, `fr`, `he`, `id`, `it`, `ja`, `ka`, `ko`, `nl`, `pt-BR`, `ro`, `ru`, `sk`, `sv`, `tr`, `uk`, `zh-CN`, `zh-TW` |
 <!-- i18n-coverage-end -->
 
 To add a new language, copy `src/i18n/locales/en.json`, translate the values, and register the file in `src/i18n/index.ts`.

--- a/src/components/BackgroundTasksDrawer.css
+++ b/src/components/BackgroundTasksDrawer.css
@@ -29,7 +29,19 @@
   flex-direction: column;
 }
 
+/* NotificationDrawer defaults to height:100%, which only resolves against a
+   parent with a definite height. Our parent (.btd-panel) only has max-height,
+   so without these overrides the drawer just grows past it and gets clipped
+   by .btd-panel's overflow:hidden instead of scrolling internally. */
+.btd-panel .pf-v6-c-notification-drawer {
+  height: auto;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
 .btd-body {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
 }
 

--- a/src/components/BackgroundTasksDrawer.test.tsx
+++ b/src/components/BackgroundTasksDrawer.test.tsx
@@ -105,4 +105,15 @@ describe("BackgroundTasksDrawer", () => {
     fireEvent.click(screen.getByText("Pull b"));
     expect(screen.queryByText(/Waiting for output/i)).not.toBeInTheDocument();
   });
+
+  it("focuses the newest (last) task row when the panel opens", () => {
+    mockTasks = [
+      { id: 1, stackName: "a", action: "up", label: "Up a", status: "success", lines: [], createdAt: 0 },
+      { id: 2, stackName: "b", action: "pull", label: "Pull b", status: "running", lines: [], createdAt: 1 },
+    ];
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    const items = screen.getAllByRole("listitem");
+    expect(items[items.length - 1]).toHaveFocus();
+  });
 });

--- a/src/components/BackgroundTasksDrawer.tsx
+++ b/src/components/BackgroundTasksDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -32,10 +32,21 @@ export function BackgroundTasksDrawer() {
   const { tasks, stop, remove } = useBackgroundTasks();
   const [open, setOpen] = useState(false);
   const [openTask, setOpenTask] = useState<BackgroundTask | null>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
 
   const activeCount = tasks.filter(t => t.status === "pending" || t.status === "running").length;
   // Reflects live status/lines of the task currently shown in the log modal, if still tracked.
   const liveOpenTask = openTask ? tasks.find(t => t.id === openTask.id) ?? openTask : null;
+
+  // Newest task is last in the list (closest to the floating icon) — scroll it
+  // into view and focus it whenever the panel opens or a new task arrives.
+  useEffect(() => {
+    if (!open || !bodyRef.current) return;
+    const items = bodyRef.current.querySelectorAll("li");
+    const last = items[items.length - 1] as HTMLElement | undefined;
+    last?.scrollIntoView?.({ block: "nearest" });
+    last?.focus();
+  }, [open, tasks.length]);
 
   return (
     <>
@@ -58,6 +69,7 @@ export function BackgroundTasksDrawer() {
               onClose={() => setOpen(false)}
             />
             <NotificationDrawerBody className="btd-body">
+              <div ref={bodyRef} className="btd-body-inner">
               {tasks.length === 0 ? (
                 <EmptyState titleText={t("background_tasks.empty_title")} headingLevel="h4">
                   <EmptyStateBody>{t("background_tasks.empty_body")}</EmptyStateBody>
@@ -108,6 +120,7 @@ export function BackgroundTasksDrawer() {
                   })}
                 </NotificationDrawerList>
               )}
+              </div>
             </NotificationDrawerBody>
           </NotificationDrawer>
         </div>

--- a/src/components/BulkActionConfirmModal.test.tsx
+++ b/src/components/BulkActionConfirmModal.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BulkActionConfirmModal } from "./BulkActionConfirmModal";
+import type { ComposeStack } from "../api";
+
+const stacks: ComposeStack[] = [
+  { Name: "a", Status: "running(1)", ConfigFiles: "/a/compose.yml" },
+  { Name: "b", Status: "stopped", ConfigFiles: "/b/compose.yml" },
+];
+
+describe("BulkActionConfirmModal", () => {
+  it("lists the affected stack names", () => {
+    render(<BulkActionConfirmModal stacks={stacks} action="up" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("b")).toBeInTheDocument();
+  });
+
+  it("shows the stack count and action in the title", () => {
+    render(<BulkActionConfirmModal stacks={stacks} action="pull" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText(/Pull 2 stacks\?/i)).toBeInTheDocument();
+  });
+
+  it("shows a notice that this will run as background tasks", () => {
+    render(<BulkActionConfirmModal stacks={stacks} action="down" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText(/run as background tasks/i)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when the primary action button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(<BulkActionConfirmModal stacks={stacks} action="up" onConfirm={onConfirm} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /^Up$/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    render(<BulkActionConfirmModal stacks={stacks} action="up" onConfirm={vi.fn()} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows a small warning (not a danger alert) for up", () => {
+    render(<BulkActionConfirmModal stacks={stacks} action="up" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText(/might restart containers and pull new images/i)).toBeInTheDocument();
+  });
+
+  it("shows a small warning for restart", () => {
+    render(<BulkActionConfirmModal stacks={stacks} action="restart" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText(/briefly be unavailable/i)).toBeInTheDocument();
+  });
+
+  it("shows a prominent danger warning for down", () => {
+    render(<BulkActionConfirmModal stacks={stacks} action="down" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText(/stops and removes all containers/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Down$/i })).toHaveClass("pf-m-danger");
+  });
+
+  it("shows a prominent danger warning for kill", () => {
+    render(<BulkActionConfirmModal stacks={stacks} action="kill" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText(/forcefully terminates every container/i)).toBeInTheDocument();
+    expect(screen.getByText(/SIGKILL/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Kill$/i })).toHaveClass("pf-m-danger");
+  });
+
+  it("does not show the destructive warning for non-destructive actions", () => {
+    render(<BulkActionConfirmModal stacks={stacks} action="pull" onConfirm={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.queryByText(/SIGKILL/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Pull$/i })).not.toHaveClass("pf-m-danger");
+  });
+});

--- a/src/components/BulkActionConfirmModal.tsx
+++ b/src/components/BulkActionConfirmModal.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button, Alert } from "@patternfly/react-core";
+import { type ComposeStack } from "../api";
+
+export type BulkAction = "up" | "pull" | "restart" | "down" | "kill";
+
+interface Props {
+  stacks: ComposeStack[];
+  action: BulkAction;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+const DESTRUCTIVE_ACTIONS: BulkAction[] = ["down", "kill"];
+const MINOR_WARNING_ACTIONS: BulkAction[] = ["up", "restart"];
+
+export function BulkActionConfirmModal({ stacks, action, onConfirm, onClose }: Props) {
+  const { t } = useTranslation();
+  const isDestructive = DESTRUCTIVE_ACTIONS.includes(action);
+
+  return (
+    <Modal isOpen onClose={onClose} variant="small" aria-label={t("bulk_confirm_modal.aria_label")}>
+      <ModalHeader title={t(`bulk_confirm_modal.title_${action}`, { count: stacks.length })} />
+      <ModalBody>
+        {isDestructive && (
+          <Alert
+            variant="danger"
+            isInline
+            title={t(`bulk_confirm_modal.warning_${action}_title`)}
+            style={{ marginBottom: "1rem" }}
+          >
+            {t(`bulk_confirm_modal.warning_${action}_body`)}
+          </Alert>
+        )}
+        {MINOR_WARNING_ACTIONS.includes(action) && (
+          <Alert
+            variant="warning"
+            isInline
+            title={t(`bulk_confirm_modal.warning_${action}`)}
+            style={{ marginBottom: "1rem" }}
+          />
+        )}
+        <Alert variant="info" isInline title={t("bulk_confirm_modal.background_notice")} style={{ marginBottom: "1rem" }} />
+        <p>{t("bulk_confirm_modal.stacks_label")}</p>
+        <ul>
+          {stacks.map(s => <li key={s.Name}>{s.Name}</li>)}
+        </ul>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant={isDestructive ? "danger" : "primary"} onClick={onConfirm}>
+          {t(`bulk_confirm_modal.confirm_button_${action}`)}
+        </Button>
+        <Button variant="link" onClick={onClose}>{t("common.cancel")}</Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/components/PullModal.tsx
+++ b/src/components/PullModal.tsx
@@ -7,9 +7,10 @@ import {
   Spinner,
 } from "@patternfly/react-core";
 import { LogViewer } from "@rxtx4816/cockpit-plugin-base-react/components";
-import { type ComposeStack, pullStack, composeFileSuperuser, isRootlessMode, readAllProfiles } from "../api";
+import { type ComposeStack } from "../api";
 import { usePullStream } from "../hooks/usePullStream";
 import { useBackgroundTasks } from "../hooks/useBackgroundTasks";
+import { buildPullStarter } from "../lib/backgroundActions";
 import "./PullModal.css";
 import { splitConfigFiles } from "../lib/configFiles";
 
@@ -31,12 +32,7 @@ export function PullModal({ stack, onClose }: Props) {
 
   const handleBackground = () => {
     cancel();
-    enqueue(stack.Name, "pull", t("pull_modal.background_label", { name: stack.Name }), launch => {
-      return Promise.all([
-        isRootlessMode() ? Promise.resolve(undefined) : composeFileSuperuser(configFiles),
-        readAllProfiles(configFiles[0]),
-      ]).then(([su, profiles]) => { launch(pullStack(stack.Name, configFiles, profiles, su)); });
-    });
+    enqueue(stack.Name, "pull", t("pull_modal.background_label", { name: stack.Name }), buildPullStarter(stack));
     onClose();
   };
 

--- a/src/components/StacksView/MinimalCard.css
+++ b/src/components/StacksView/MinimalCard.css
@@ -46,6 +46,23 @@
   opacity: 1;
 }
 
+/* Select checkbox in top-left — ghost until card hovered, any card selected, or checked */
+.mc-select {
+  position: absolute;
+  top: 0.2rem;
+  left: 0.3rem;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  cursor: pointer;
+}
+
+.mc-card:hover .mc-select,
+.mc-card:focus-within .mc-select,
+.mc-select--visible {
+  opacity: 1;
+}
+
 .mc-menu-toggle.pf-v6-c-menu-toggle {
   padding: 0.15rem 0.2rem;
   min-width: unset;

--- a/src/components/StacksView/MinimalCard.test.tsx
+++ b/src/components/StacksView/MinimalCard.test.tsx
@@ -253,4 +253,21 @@ describe("MinimalCard", () => {
     fireEvent.click(screen.getByText(/^start$/i));
     expect(doAction).toHaveBeenCalledWith("start", expect.any(Function));
   });
+
+  describe("selection", () => {
+    it("does not render a checkbox when onToggleSelect is not provided", () => {
+      render(<MinimalCard {...defaultProps} />);
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    });
+
+    it("renders a checkbox reflecting isSelected and calls onToggleSelect on click, without opening the container bubble", () => {
+      const onToggleSelect = vi.fn();
+      render(<MinimalCard {...defaultProps} onToggleSelect={onToggleSelect} isSelected />);
+      const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+      fireEvent.click(checkbox);
+      expect(onToggleSelect).toHaveBeenCalledOnce();
+      expect(screen.queryByText(/no containers/i)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/StacksView/MinimalCard.tsx
+++ b/src/components/StacksView/MinimalCard.tsx
@@ -64,6 +64,9 @@ interface MinimalCardProps {
   onBackup: () => void;
   onScale: () => void;
   onActingChange: (delta: 1 | -1) => void;
+  isSelected?: boolean;
+  onToggleSelect?: () => void;
+  anySelected?: boolean;
 }
 
 const STATUS_VARS: Record<string, { bg: string; border: string }> = {
@@ -77,6 +80,7 @@ const STATUS_VARS: Record<string, { bg: string; border: string }> = {
 export function MinimalCard({
   stack, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull,
   onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange,
+  isSelected = false, onToggleSelect, anySelected = false,
 }: MinimalCardProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -116,7 +120,7 @@ export function MinimalCard({
 
   const handleCardClick = (e: MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
-    if (target.closest("button, [role=button], .pf-v6-c-dropdown")) return;
+    if (target.closest("button, input, [role=button], .pf-v6-c-dropdown")) return;
     if (bubble) {
       setBubble(null);
     } else {
@@ -151,6 +155,16 @@ export function MinimalCard({
         aria-label={`${stack.Name} — ${status}`}
         onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") handleCardClick(e as unknown as MouseEvent<HTMLDivElement>); }}
       >
+        {onToggleSelect && (
+          <input
+            type="checkbox"
+            className={`mc-select${anySelected ? " mc-select--visible" : ""}`}
+            checked={isSelected}
+            onChange={onToggleSelect}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={t("stacks.select_stack", { name: stack.Name })}
+          />
+        )}
         <div className="mc-kebab" onClick={(e) => e.stopPropagation()}>
           <Dropdown
             isOpen={menuOpen}

--- a/src/components/StacksView/PrettyCard.css
+++ b/src/components/StacksView/PrettyCard.css
@@ -44,6 +44,23 @@
   100% { box-shadow: 0 0 0 0 rgba(110, 198, 100, 0); }
 }
 
+/* Select checkbox in top-left — ghost until card hovered, any card selected, or checked */
+.pc-select {
+  position: absolute;
+  top: 0.45rem;
+  left: 0.5rem;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  cursor: pointer;
+}
+
+.pc-card:hover .pc-select,
+.pc-card:focus-within .pc-select,
+.pc-select--visible {
+  opacity: 1;
+}
+
 /* Header */
 .pc-header {
   display: flex;

--- a/src/components/StacksView/PrettyCard.test.tsx
+++ b/src/components/StacksView/PrettyCard.test.tsx
@@ -301,4 +301,20 @@ describe("PrettyCard", () => {
     render(<PrettyCard {...defaultProps} expanded={true} />);
     expect(screen.getByLabelText("Start service")).toBeInTheDocument();
   });
+
+  describe("selection", () => {
+    it("does not render a checkbox when onToggleSelect is not provided", () => {
+      render(<PrettyCard {...defaultProps} />);
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    });
+
+    it("renders a checkbox reflecting isSelected and calls onToggleSelect on click", () => {
+      const onToggleSelect = vi.fn();
+      render(<PrettyCard {...defaultProps} onToggleSelect={onToggleSelect} isSelected />);
+      const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+      fireEvent.click(checkbox);
+      expect(onToggleSelect).toHaveBeenCalledOnce();
+    });
+  });
 });

--- a/src/components/StacksView/PrettyCard.tsx
+++ b/src/components/StacksView/PrettyCard.tsx
@@ -66,6 +66,9 @@ interface PrettyCardProps {
   onBackup: () => void;
   onScale: () => void;
   onActingChange: (delta: 1 | -1) => void;
+  isSelected?: boolean;
+  onToggleSelect?: () => void;
+  anySelected?: boolean;
 }
 
 const STATUS_BORDER: Record<string, string> = {
@@ -87,6 +90,7 @@ const STATUS_GLOW: Record<string, string> = {
 export function PrettyCard({
   stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull,
   onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange,
+  isSelected = false, onToggleSelect, anySelected = false,
 }: PrettyCardProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -136,6 +140,16 @@ export function PrettyCard({
         data-stack-name={stack.Name}
       >
         {status === "running" && <span className="pc-pulse" />}
+
+        {onToggleSelect && (
+          <input
+            type="checkbox"
+            className={`pc-select${anySelected ? " pc-select--visible" : ""}`}
+            checked={isSelected}
+            onChange={onToggleSelect}
+            aria-label={t("stacks.select_stack", { name: stack.Name })}
+          />
+        )}
 
         {/* Header */}
         <div className="pc-header">

--- a/src/components/StacksView/StackRow.css
+++ b/src/components/StacksView/StackRow.css
@@ -1,3 +1,14 @@
+.sr-check {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.sr-check--visible,
+.pf-v6-c-data-list__item-row:hover .sr-check,
+.pf-v6-c-data-list__item-row:focus-within .sr-check {
+  opacity: 1;
+}
+
 .sr-name-cell {
   display: flex;
   align-items: center;

--- a/src/components/StacksView/StackRow.test.tsx
+++ b/src/components/StacksView/StackRow.test.tsx
@@ -406,4 +406,35 @@ describe("StackRow", () => {
     expect(clearContainers).toHaveBeenCalled();
     expect(loadContainers).toHaveBeenCalled();
   });
+
+  describe("selection", () => {
+    it("does not render a checkbox when onToggleSelect is not provided", () => {
+      render(<StackRow {...defaultProps} />);
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    });
+
+    it("renders a checkbox reflecting isSelected when onToggleSelect is provided", () => {
+      render(<StackRow {...defaultProps} onToggleSelect={vi.fn()} isSelected />);
+      expect((screen.getByRole("checkbox") as HTMLInputElement).checked).toBe(true);
+    });
+
+    it("calls onToggleSelect when the checkbox is clicked, without also toggling row expansion", () => {
+      const onToggleSelect = vi.fn();
+      const onToggle = vi.fn();
+      render(<StackRow {...defaultProps} onToggle={onToggle} onToggleSelect={onToggleSelect} />);
+      fireEvent.click(screen.getByRole("checkbox"));
+      expect(onToggleSelect).toHaveBeenCalledOnce();
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+
+    it("adds the visible modifier class once any row is selected", () => {
+      const { container } = render(<StackRow {...defaultProps} onToggleSelect={vi.fn()} anySelected />);
+      expect(container.querySelector(".sr-check--visible")).toBeInTheDocument();
+    });
+
+    it("omits the visible modifier class when nothing is selected", () => {
+      const { container } = render(<StackRow {...defaultProps} onToggleSelect={vi.fn()} anySelected={false} />);
+      expect(container.querySelector(".sr-check--visible")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/StacksView/StackRow.tsx
+++ b/src/components/StacksView/StackRow.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   DataListItem,
   DataListItemRow,
+  DataListCheck,
   DataListToggle,
   DataListItemCells,
   DataListCell,
@@ -78,9 +79,12 @@ interface StackRowProps {
   onBackup: () => void;
   onScale: () => void;
   onActingChange: (delta: 1 | -1) => void;
+  isSelected?: boolean;
+  onToggleSelect?: () => void;
+  anySelected?: boolean;
 }
 
-export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull, onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange }: StackRowProps) {
+export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull, onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange, isSelected = false, onToggleSelect, anySelected = false }: StackRowProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmStopOpen, setConfirmStopOpen] = useState(false);
@@ -124,6 +128,15 @@ export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, on
     <>
     <DataListItem isExpanded={expanded} aria-labelledby={`stack-${stack.Name}`} data-status={status} data-stack-name={stack.Name}>
       <DataListItemRow onClick={handleRowClick} style={{ cursor: "pointer" }}>
+        {onToggleSelect && (
+          <DataListCheck
+            aria-labelledby={`stack-${stack.Name}`}
+            aria-label={t("stacks.select_stack", { name: stack.Name })}
+            isChecked={isSelected}
+            onChange={onToggleSelect}
+            className={`sr-check${anySelected ? " sr-check--visible" : ""}`}
+          />
+        )}
         <DataListToggle
           onClick={handleToggle}
           isExpanded={expanded}

--- a/src/components/StacksView/StacksView.css
+++ b/src/components/StacksView/StacksView.css
@@ -46,6 +46,19 @@
   flex-wrap: wrap;
 }
 
+.sv-bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  animation: sv-search-in 0.15s ease-out;
+}
+
+.sv-bulk-count {
+  font-size: var(--pf-t--global--font--size--sm);
+  color: var(--pf-t--global--text--color--subtle);
+  white-space: nowrap;
+}
+
 .sv-filter-chip {
   cursor: pointer;
   user-select: none;

--- a/src/components/StacksView/UnixRow.css
+++ b/src/components/StacksView/UnixRow.css
@@ -171,6 +171,12 @@
   cursor: not-allowed;
 }
 
+.ur-key--select-on {
+  background: var(--pf-t--global--color--brand--default, #06c);
+  color: #fff;
+  border-color: var(--pf-t--global--color--brand--default, #06c);
+}
+
 .ur-key--up {
   border-color: #3e8635;
   color: #3e8635;

--- a/src/components/StacksView/UnixRow.test.tsx
+++ b/src/components/StacksView/UnixRow.test.tsx
@@ -298,4 +298,23 @@ describe("UnixRow", () => {
     render(<UnixRow {...defaultProps} stack={{ ...stack, Status: "paused(2)" }} />);
     expect(screen.getByText("PAUSED")).toBeInTheDocument();
   });
+
+  describe("selection", () => {
+    it("does not render a select toggle when onToggleSelect is not provided", () => {
+      render(<UnixRow {...defaultProps} />);
+      expect(screen.queryByText("[ ]")).not.toBeInTheDocument();
+      expect(screen.queryByText("[x]")).not.toBeInTheDocument();
+    });
+
+    it("shows [ ] when unselected and [x] when selected, and calls onToggleSelect on click", () => {
+      const onToggleSelect = vi.fn();
+      const { rerender } = render(<UnixRow {...defaultProps} onToggleSelect={onToggleSelect} isSelected={false} />);
+      expect(screen.getByText("[ ]")).toBeInTheDocument();
+      fireEvent.click(screen.getByText("[ ]"));
+      expect(onToggleSelect).toHaveBeenCalledOnce();
+
+      rerender(<UnixRow {...defaultProps} onToggleSelect={onToggleSelect} isSelected={true} />);
+      expect(screen.getByText("[x]")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/StacksView/UnixRow.tsx
+++ b/src/components/StacksView/UnixRow.tsx
@@ -58,6 +58,8 @@ interface UnixRowProps {
   onBackup: () => void;
   onScale: () => void;
   onActingChange: (delta: 1 | -1) => void;
+  isSelected?: boolean;
+  onToggleSelect?: () => void;
 }
 
 const STATUS_LABEL: Record<string, { text: string; cls: string }> = {
@@ -71,6 +73,7 @@ const STATUS_LABEL: Record<string, { text: string; cls: string }> = {
 export function UnixRow({
   stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull,
   onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange,
+  isSelected = false, onToggleSelect,
 }: UnixRowProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -156,6 +159,18 @@ export function UnixRow({
         </span>
 
         <div className="ur-col ur-col--actions">
+          {onToggleSelect && (
+            <Tooltip content={t("stacks.select_stack", { name: stack.Name })}>
+              <button
+                className={`ur-key ur-key--select${isSelected ? " ur-key--select-on" : ""}`}
+                onClick={onToggleSelect}
+                aria-label={t("stacks.select_stack", { name: stack.Name })}
+                aria-pressed={isSelected}
+              >
+                {isSelected ? "[x]" : "[ ]"}
+              </button>
+            </Tooltip>
+          )}
           {isUp ? (
             <Tooltip content={t("actions.stop")}>
               <button className="ur-key ur-key--stop" onClick={() => setConfirmStopOpen(true)} disabled={acting}>[stop]</button>

--- a/src/components/StacksView/index.test.tsx
+++ b/src/components/StacksView/index.test.tsx
@@ -15,12 +15,14 @@ vi.mock("./StackRow", () => ({
   StackRow: ({
     stack,
     onLogs, onYaml, onInfo, onUp, onPull, onEvents, onTop, onExec, onRun, onPrune, onBackup, onDown, onKill, onToggle,
+    isSelected, onToggleSelect,
   }: {
     stack: ComposeStack;
     onLogs: () => void; onYaml: () => void; onInfo: () => void; onUp: () => void;
     onPull: () => void; onEvents: () => void; onTop: () => void; onExec: () => void;
     onRun: () => void; onPrune: () => void; onBackup: () => void; onDown: () => void; onKill: () => void;
     onToggle: () => void;
+    isSelected?: boolean; onToggleSelect?: () => void;
   }) => (
     <div data-testid={`stack-row-${stack.Name}`}>
       <span>{stack.Name}</span>
@@ -38,6 +40,9 @@ vi.mock("./StackRow", () => ({
       <button onClick={onDown}>Down</button>
       <button onClick={onKill}>Kill</button>
       <button onClick={onToggle}>Toggle</button>
+      {onToggleSelect && (
+        <input type="checkbox" aria-label={`select-${stack.Name}`} checked={isSelected} onChange={onToggleSelect} />
+      )}
     </div>
   ),
 }));
@@ -142,6 +147,31 @@ vi.mock("./UnixRow", () => ({
   ),
 }));
 
+const mockEnqueue = vi.fn();
+const mockClearPending = vi.fn(() => 0);
+vi.mock("../../hooks/useBackgroundTasks", () => ({
+  useBackgroundTasks: () => ({ tasks: [], enqueue: mockEnqueue, stop: vi.fn(), remove: vi.fn(), clearPending: mockClearPending }),
+}));
+
+const mockToastWarn = vi.fn();
+vi.mock("../ToastProvider", () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn(), warn: mockToastWarn, info: vi.fn(), addToast: vi.fn() }),
+}));
+
+vi.mock("../BulkActionConfirmModal", () => ({
+  BulkActionConfirmModal: ({
+    stacks, action, onConfirm, onClose,
+  }: {
+    stacks: ComposeStack[]; action: string; onConfirm: () => void; onClose: () => void;
+  }) => (
+    <div data-testid="bulk-confirm-modal">
+      <span>{action} {stacks.map(s => s.Name).join(",")}</span>
+      <button onClick={onConfirm}>Confirm</button>
+      <button onClick={onClose}>Cancel</button>
+    </div>
+  ),
+}));
+
 import { useComposeStacks } from "../../hooks/useComposeStacks";
 import { useDownStack } from "../../hooks/useDownStack";
 import { useKillStack } from "../../hooks/useKillStack";
@@ -174,6 +204,9 @@ beforeEach(() => {
   mockUseDownStack.mockReturnValue(defaultDownStack);
   mockUseKillStack.mockReturnValue(defaultKillStack);
   mockUseSharedNetworks.mockReturnValue({ sharedNetworks: [], loading: false, error: null });
+  mockEnqueue.mockReset();
+  mockClearPending.mockReset().mockReturnValue(0);
+  mockToastWarn.mockReset();
 });
 
 describe("StacksView — loading and empty states", () => {
@@ -513,6 +546,30 @@ describe("StacksView — onRuntimeChange prop", () => {
     render(<StacksView />);
     expect(() => fireEvent.click(screen.getByTestId("runtime-toggle"))).not.toThrow();
   });
+
+  it("clears the stack selection when the runtime changes", () => {
+    mockUseComposeStacks.mockReturnValue({ stacks: [stack], loading: false, error: null, refresh: vi.fn(), reset: vi.fn() });
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("runtime-toggle"));
+    expect(screen.queryByText(/selected/i)).toBeNull();
+  });
+
+  it("cancels pending background tasks when the runtime changes, since they'd otherwise run against the new runtime", () => {
+    mockClearPending.mockReturnValue(2);
+    render(<StacksView />);
+    fireEvent.click(screen.getByTestId("runtime-toggle"));
+    expect(mockClearPending).toHaveBeenCalled();
+    expect(mockToastWarn).toHaveBeenCalledWith(expect.stringContaining("2"));
+  });
+
+  it("does not show a toast when there were no pending tasks to cancel", () => {
+    mockClearPending.mockReturnValue(0);
+    render(<StacksView />);
+    fireEvent.click(screen.getByTestId("runtime-toggle"));
+    expect(mockToastWarn).not.toHaveBeenCalled();
+  });
 });
 
 describe("StacksView — layout variants", () => {
@@ -625,5 +682,86 @@ describe("StacksView — modal close callbacks", () => {
     expect(screen.getByTestId("pull-modal")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "ClosePull" }));
     expect(screen.queryByTestId("pull-modal")).toBeNull();
+  });
+});
+
+describe("StacksView — bulk selection and bulk actions", () => {
+  const stack2: ComposeStack = { Name: "otherapp", Status: "exit(1)", ConfigFiles: "/other/compose.yml" };
+
+  beforeEach(() => {
+    mockUseComposeStacks.mockReturnValue({ stacks: [stack, stack2], loading: false, error: null, refresh: vi.fn(), reset: vi.fn() });
+  });
+
+  it("does not show the bulk action bar when nothing is selected", () => {
+    render(<StacksView />);
+    expect(screen.queryByTestId("bulk-confirm-modal")).toBeNull();
+    expect(screen.queryByText(/selected/i)).toBeNull();
+  });
+
+  it("shows the bulk action bar once a stack is selected", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+  });
+
+  it("selecting multiple stacks and confirming Up opens the bulk modal with both stacks, then enqueues one task per stack", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(screen.getByLabelText("select-otherapp"));
+    fireEvent.click(within(screen.getByTestId("sv-bulk-bar")).getByRole("button", { name: "Up" }));
+    expect(screen.getByTestId("bulk-confirm-modal")).toBeInTheDocument();
+    expect(screen.getByText("up myapp,otherapp")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(mockEnqueue).toHaveBeenCalledTimes(2);
+    expect(mockEnqueue.mock.calls[0][0]).toBe("myapp");
+    expect(mockEnqueue.mock.calls[0][1]).toBe("up");
+    expect(mockEnqueue.mock.calls[1][0]).toBe("otherapp");
+  });
+
+  it("clears the selection and closes the modal after confirming", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(within(screen.getByTestId("sv-bulk-bar")).getByRole("button", { name: /Pull/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(screen.queryByTestId("bulk-confirm-modal")).toBeNull();
+    expect(screen.queryByText(/selected/i)).toBeNull();
+  });
+
+  it("closing the bulk modal without confirming keeps the selection intact", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(within(screen.getByTestId("sv-bulk-bar")).getByRole("button", { name: /Down/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByTestId("bulk-confirm-modal")).toBeNull();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+  });
+
+  it("Clear selection link empties the selection", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(screen.getByRole("button", { name: /clear selection/i }));
+    expect(screen.queryByText(/selected/i)).toBeNull();
+  });
+
+  it("supports bulk restart", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(within(screen.getByTestId("sv-bulk-bar")).getByRole("button", { name: /Restart/i }));
+    expect(screen.getByTestId("bulk-confirm-modal")).toBeInTheDocument();
+    expect(screen.getByText("restart myapp")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(mockEnqueue).toHaveBeenCalledWith("myapp", "restart", expect.anything(), expect.any(Function));
+  });
+
+  it("supports bulk kill", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(within(screen.getByTestId("sv-bulk-bar")).getByRole("button", { name: /^Kill$/i }));
+    expect(screen.getByTestId("bulk-confirm-modal")).toBeInTheDocument();
+    expect(screen.getByText("kill myapp")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(mockEnqueue).toHaveBeenCalledWith("myapp", "kill", expect.anything(), expect.any(Function));
   });
 });

--- a/src/components/StacksView/index.tsx
+++ b/src/components/StacksView/index.tsx
@@ -28,7 +28,10 @@ import {
 } from "@patternfly/react-core";
 import { Tooltip } from "@rxtx4816/cockpit-plugin-base-react/components";
 import { type ComposeStack, type Runtime } from "../../api";
-import { TimesCircleIcon, BanIcon, PlusCircleIcon, FolderOpenIcon, SearchIcon, ExclamationTriangleIcon } from "@patternfly/react-icons";
+import {
+  TimesCircleIcon, TimesIcon, BanIcon, PlusCircleIcon, FolderOpenIcon, SearchIcon, ExclamationTriangleIcon,
+  DownloadIcon, RedoAltIcon, ArrowAltCircleDownIcon,
+} from "@patternfly/react-icons";
 import { type DownedStack } from "../../hooks/useDownedStacksScan";
 import { useComposeStacks } from "../../hooks/useComposeStacks";
 import { useAutoRefresh } from "../../hooks/useAutoRefresh";
@@ -49,6 +52,10 @@ import { PruneModal } from "../PruneModal";
 import { BackupModal } from "../BackupModal";
 import { ScaleModal } from "../ScaleModal";
 import { DownedStacksSection } from "../DownedStacksSection";
+import { BulkActionConfirmModal, type BulkAction } from "../BulkActionConfirmModal";
+import { useBackgroundTasks } from "../../hooks/useBackgroundTasks";
+import { useToast } from "../ToastProvider";
+import { buildUpStarter, buildPullStarter, buildRestartStarter, buildDownStarter, buildKillStarter } from "../../lib/backgroundActions";
 import { StackRow } from "./StackRow";
 import { MinimalCard } from "./MinimalCard";
 import { PrettyCard } from "./PrettyCard";
@@ -60,6 +67,14 @@ import { StackSkeleton } from "./StackSkeleton";
 import "./StacksView.css";
 import { splitConfigFiles } from "../../lib/configFiles";
 import { type Layout } from "../../lib/layout";
+
+const BULK_STARTERS: Record<BulkAction, typeof buildUpStarter> = {
+  up: buildUpStarter,
+  pull: buildPullStarter,
+  restart: buildRestartStarter,
+  down: buildDownStarter,
+  kill: buildKillStarter,
+};
 
 const filterColorMap: Record<string, "green" | "orange" | "grey" | "blue"> = {
   running: "green",
@@ -92,13 +107,24 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
     down: ComposeStack; kill: ComposeStack; env: ComposeStack;
     scale: ComposeStack; prune: ComposeStack; exec: ComposeStack;
     run: ComposeStack; events: ComposeStack; top: ComposeStack; backup: ComposeStack;
+    bulkConfirm: { stacks: ComposeStack[]; action: BulkAction };
   };
   const MODAL_NAMES = [
     "logs", "yaml", "info", "upConfirm", "up", "pullConfirm", "pull",
-    "down", "kill", "env", "scale", "prune", "exec", "run", "events", "top", "backup",
+    "down", "kill", "env", "scale", "prune", "exec", "run", "events", "top", "backup", "bulkConfirm",
   ] as const;
   const modals = useDialogState<ComposeModals>(MODAL_NAMES);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const toggleSelect = useCallback((name: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      return next;
+    });
+  }, []);
   const [upProfiles, setUpProfiles] = useState<string[]>([]);
+  const { enqueue, clearPending } = useBackgroundTasks();
+  const toast = useToast();
   const { expanded, toggleExpanded } = useExpandedStacks();
   const { activeOps, increment, decrement } = useOperationCounter();
   const {
@@ -132,6 +158,22 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
   const handleUpComplete = useCallback((name: string) => {
     setManuallyDownedStacks(prev => prev.filter(d => d.name.toLowerCase() !== name.toLowerCase()));
   }, []);
+
+  const handleBulkConfirm = useCallback(() => {
+    const data = modals.getData("bulkConfirm");
+    if (!data) return;
+    const buildStarter = BULK_STARTERS[data.action];
+    for (const stack of data.stacks) {
+      enqueue(
+        stack.Name,
+        data.action,
+        t(`${data.action}_modal.background_label`, { name: stack.Name }),
+        buildStarter(stack),
+      );
+    }
+    setSelected(new Set());
+    modals.close("bulkConfirm");
+  }, [modals, enqueue, t]);
 
   const { target: downTarget, downing, error: downError, open: openDown, close: closeDown, execute: performDown }
     = useDownStack(refresh, onActingChange, handleDownComplete);
@@ -251,10 +293,98 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
             </ToolbarItem>
           )}
 
+          {selected.size > 0 && (
+            <ToolbarItem>
+              <div className="sv-bulk-bar" data-testid="sv-bulk-bar">
+                <span className="sv-bulk-count">{t("stacks.bulk_selected", { count: selected.size })}</span>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => modals.open("bulkConfirm", {
+                    stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "up",
+                  })}
+                >
+                  {t("actions.up")}
+                </Button>
+                <span className="sr-icon-group">
+                  <Tooltip content={t("actions.restart")}>
+                    <Button
+                      variant="plain"
+                      size="sm"
+                      aria-label={t("actions.restart")}
+                      onClick={() => modals.open("bulkConfirm", {
+                        stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "restart",
+                      })}
+                    >
+                      <RedoAltIcon />
+                    </Button>
+                  </Tooltip>
+                  <Tooltip content={t("actions.pull_title")}>
+                    <Button
+                      variant="plain"
+                      size="sm"
+                      aria-label={t("actions.pull_title")}
+                      onClick={() => modals.open("bulkConfirm", {
+                        stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "pull",
+                      })}
+                    >
+                      <DownloadIcon />
+                    </Button>
+                  </Tooltip>
+                  <Tooltip content={t("actions.down_title")}>
+                    <Button
+                      variant="plain"
+                      size="sm"
+                      className="sr-down-btn"
+                      aria-label={t("actions.down_title")}
+                      onClick={() => modals.open("bulkConfirm", {
+                        stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "down",
+                      })}
+                    >
+                      <ArrowAltCircleDownIcon />
+                    </Button>
+                  </Tooltip>
+                  <Tooltip content={t("actions.kill")}>
+                    <Button
+                      variant="plain"
+                      size="sm"
+                      aria-label={t("actions.kill")}
+                      onClick={() => modals.open("bulkConfirm", {
+                        stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "kill",
+                      })}
+                    >
+                      <BanIcon />
+                    </Button>
+                  </Tooltip>
+                </span>
+                <Tooltip content={t("stacks.bulk_clear")}>
+                  <Button
+                    variant="plain"
+                    size="sm"
+                    aria-label={t("stacks.bulk_clear")}
+                    onClick={() => setSelected(new Set())}
+                  >
+                    <TimesIcon />
+                  </Button>
+                </Tooltip>
+              </div>
+            </ToolbarItem>
+          )}
+
           <ToolbarItem align={{ default: "alignEnd" }}>
             <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
               <LayoutSelector layout={layout} onLayoutChange={onLayoutChange} />
-              <RuntimeToggle onRuntimeChange={(r) => { setRuntimeSwitchKey(k => k + 1); reset(); onRuntimeChange?.(r); }} suggestPodman={dockerMissing} />
+              <RuntimeToggle
+                onRuntimeChange={(r) => {
+                  setRuntimeSwitchKey(k => k + 1);
+                  reset();
+                  setSelected(new Set());
+                  const cancelled = clearPending();
+                  if (cancelled > 0) toast.warn(t("stacks.runtime_switch_cancelled_tasks", { count: cancelled }));
+                  onRuntimeChange?.(r);
+                }}
+                suggestPodman={dockerMissing}
+              />
             </div>
           </ToolbarItem>
         </ToolbarContent>
@@ -337,6 +467,9 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onBackup={() => modals.open("backup", stack)}
               onScale={() => modals.open("scale", stack)}
               onActingChange={onActingChange}
+              isSelected={selected.has(stack.Name)}
+              onToggleSelect={() => toggleSelect(stack.Name)}
+              anySelected={selected.size > 0}
             />
           ))}
         </div>
@@ -363,6 +496,9 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onBackup={() => modals.open("backup", stack)}
               onScale={() => modals.open("scale", stack)}
               onActingChange={onActingChange}
+              isSelected={selected.has(stack.Name)}
+              onToggleSelect={() => toggleSelect(stack.Name)}
+              anySelected={selected.size > 0}
             />
           ))}
         </div>
@@ -399,6 +535,8 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onBackup={() => modals.open("backup", stack)}
               onScale={() => modals.open("scale", stack)}
               onActingChange={onActingChange}
+              isSelected={selected.has(stack.Name)}
+              onToggleSelect={() => toggleSelect(stack.Name)}
             />
           ))}
         </div>
@@ -425,6 +563,9 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onBackup={() => modals.open("backup", stack)}
               onScale={() => modals.open("scale", stack)}
               onActingChange={onActingChange}
+              isSelected={selected.has(stack.Name)}
+              onToggleSelect={() => toggleSelect(stack.Name)}
+              anySelected={selected.size > 0}
             />
           ))}
         </DataList>
@@ -503,6 +644,14 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
       )}
       {modals.isOpen("scale") && (
         <ScaleModal stack={modals.getData("scale")!} onClose={() => modals.close("scale")} onSuccess={refresh} />
+      )}
+      {modals.isOpen("bulkConfirm") && (
+        <BulkActionConfirmModal
+          stacks={modals.getData("bulkConfirm")!.stacks}
+          action={modals.getData("bulkConfirm")!.action}
+          onConfirm={handleBulkConfirm}
+          onClose={() => modals.close("bulkConfirm")}
+        />
       )}
 
       {downTarget && (

--- a/src/components/UpModal.tsx
+++ b/src/components/UpModal.tsx
@@ -7,9 +7,10 @@ import {
   Spinner,
 } from "@patternfly/react-core";
 import { LogViewer } from "@rxtx4816/cockpit-plugin-base-react/components";
-import { type ComposeStack, upStackStream, composeFileSuperuser, isRootlessMode } from "../api";
+import { type ComposeStack } from "../api";
 import { useUpStream } from "../hooks/useUpStream";
 import { useBackgroundTasks } from "../hooks/useBackgroundTasks";
+import { buildUpStarter } from "../lib/backgroundActions";
 import "./UpModal.css";
 import { splitConfigFiles } from "../lib/configFiles";
 
@@ -32,10 +33,7 @@ export function UpModal({ stack, profiles = [], onClose }: Props) {
 
   const handleBackground = () => {
     cancel();
-    enqueue(stack.Name, "up", t("up_modal.background_label", { name: stack.Name }), launch => {
-      const suPromise = isRootlessMode() ? Promise.resolve(undefined) : composeFileSuperuser(configFiles);
-      return suPromise.then(su => { launch(upStackStream(stack.Name, configFiles, profiles, su)); });
-    });
+    enqueue(stack.Name, "up", t("up_modal.background_label", { name: stack.Name }), buildUpStarter(stack, profiles));
     onClose(true);
   };
 

--- a/src/hooks/useBackgroundTasks.test.tsx
+++ b/src/hooks/useBackgroundTasks.test.tsx
@@ -139,4 +139,45 @@ describe("useBackgroundTasks", () => {
     expect(result.current.tasks).toHaveLength(1);
     expect(start2).not.toHaveBeenCalled();
   });
+
+  describe("clearPending", () => {
+    it("removes only pending tasks, leaving the running one alone, and returns the removed count", () => {
+      const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+      const start2 = vi.fn();
+      const start3 = vi.fn();
+
+      act(() => {
+        result.current.enqueue("a", "up", "Up a", launch => launch(fakeProcess("resolve"))); // becomes running
+        result.current.enqueue("b", "up", "Up b", start2); // stays pending
+        result.current.enqueue("c", "up", "Up c", start3); // stays pending
+      });
+      expect(result.current.tasks[0].status).toBe("running");
+      expect(result.current.tasks[1].status).toBe("pending");
+      expect(result.current.tasks[2].status).toBe("pending");
+
+      let removedCount = -1;
+      act(() => { removedCount = result.current.clearPending(); });
+
+      expect(removedCount).toBe(2);
+      expect(result.current.tasks).toHaveLength(1);
+      expect(result.current.tasks[0].stackName).toBe("a");
+      expect(start2).not.toHaveBeenCalled();
+      expect(start3).not.toHaveBeenCalled();
+    });
+
+    it("does not affect a task that has already started running by the time it's called", async () => {
+      const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+      act(() => { result.current.enqueue("a", "up", "Up a", launch => launch(fakeProcess("resolve"))); });
+      await waitFor(() => expect(result.current.tasks[0].status).toBe("success"));
+
+      const removedCount = result.current.clearPending();
+      expect(removedCount).toBe(0);
+      expect(result.current.tasks).toHaveLength(1);
+    });
+
+    it("returns 0 and is a no-op when there are no tasks at all (noop fallback outside a provider)", () => {
+      const { result } = renderHook(() => useBackgroundTasks());
+      expect(result.current.clearPending()).toBe(0);
+    });
+  });
 });

--- a/src/hooks/useBackgroundTasks.tsx
+++ b/src/hooks/useBackgroundTasks.tsx
@@ -35,6 +35,16 @@ export interface BackgroundTasksContextValue {
   stop: (id: number) => void;
   /** Removes a task from the list. No-op while the task is still running. */
   remove: (id: number) => void;
+  /**
+   * Drops every not-yet-started task and returns how many were removed.
+   *
+   * Pending tasks hold a closure that calls into `compose()`/`cli()`, which read
+   * the *live* docker/podman runtime at execution time, not at enqueue time —
+   * so a task queued before a runtime switch would otherwise run against the
+   * wrong backend once it finally starts. Already-running or finished tasks
+   * already dispatched their command under the correct runtime, so they're safe.
+   */
+  clearPending: () => number;
 }
 
 const BackgroundTasksContext = createContext<BackgroundTasksContextValue | null>(null);
@@ -44,6 +54,7 @@ const NOOP_BACKGROUND_TASKS: BackgroundTasksContextValue = {
   enqueue: () => {},
   stop: () => {},
   remove: () => {},
+  clearPending: () => 0,
 };
 
 /**
@@ -133,8 +144,16 @@ export function BackgroundTasksProvider({ children }: { children: ReactNode }) {
     startersRef.current.delete(id);
   }, []);
 
+  const clearPending = useCallback((): number => {
+    const pendingIds = tasks.filter(t => t.status === "pending").map(t => t.id);
+    if (pendingIds.length === 0) return 0;
+    setTasks(prev => prev.filter(t => t.status !== "pending"));
+    for (const id of pendingIds) startersRef.current.delete(id);
+    return pendingIds.length;
+  }, [tasks]);
+
   return (
-    <BackgroundTasksContext.Provider value={{ tasks, enqueue, stop, remove }}>
+    <BackgroundTasksContext.Provider value={{ tasks, enqueue, stop, remove, clearPending }}>
       {children}
     </BackgroundTasksContext.Provider>
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -46,7 +46,9 @@
     "select_stack": "Select {{name}}",
     "select_all": "Select all",
     "bulk_selected": "{{count}} selected",
-    "bulk_clear": "Clear selection"
+    "bulk_clear": "Clear selection",
+    "runtime_switch_cancelled_tasks_one": "Cancelled {{count}} pending background task because the runtime changed",
+    "runtime_switch_cancelled_tasks_other": "Cancelled {{count}} pending background tasks because the runtime changed"
   },
   "actions": {
     "up": "Up",
@@ -129,7 +131,8 @@
     "confirm_button": "Down (remove)",
     "checking_networks": "Checking for shared networks…",
     "shared_networks_title": "Shared networks detected",
-    "shared_with": "also used by"
+    "shared_with": "also used by",
+    "background_label": "Down — {{name}}"
   },
   "kill_modal": {
     "aria_label": "Confirm kill",
@@ -137,7 +140,8 @@
     "body_prefix": "Running",
     "body_sigkill": "sends SIGKILL to all containers in",
     "body_suffix": ", forcefully terminating them immediately. Unlike Stop, processes have no chance to clean up. Use only when Stop does not respond.",
-    "confirm_button": "Kill all containers"
+    "confirm_button": "Kill all containers",
+    "background_label": "Kill — {{name}}"
   },
   "stop_modal": {
     "aria_label": "Confirm stop",
@@ -149,7 +153,8 @@
     "aria_label": "Confirm restart",
     "title": "Restart \"{{name}}\"?",
     "body": "This will restart all running services. Services will briefly be unavailable.",
-    "confirm_button": "Restart"
+    "confirm_button": "Restart",
+    "background_label": "Restart — {{name}}"
   },
   "delete_modal": {
     "aria_label": "Delete compose stack — {{name}}",
@@ -636,5 +641,31 @@
     "stop_button": "Stop",
     "remove_button": "Remove",
     "log_empty": "Waiting for output…"
+  },
+  "bulk_confirm_modal": {
+    "aria_label": "Confirm bulk action",
+    "title_up_one": "Run Up on {{count}} stack?",
+    "title_up_other": "Run Up on {{count}} stacks?",
+    "title_pull_one": "Pull {{count}} stack?",
+    "title_pull_other": "Pull {{count}} stacks?",
+    "title_restart_one": "Restart {{count}} stack?",
+    "title_restart_other": "Restart {{count}} stacks?",
+    "title_down_one": "Down {{count}} stack?",
+    "title_down_other": "Down {{count}} stacks?",
+    "title_kill_one": "Kill {{count}} stack?",
+    "title_kill_other": "Kill {{count}} stacks?",
+    "background_notice": "This will run as background tasks. You can monitor, stop, or remove them from the background tasks panel.",
+    "warning_up": "This might restart containers and pull new images if any service configuration changed.",
+    "warning_restart": "Running services in the selected stacks will briefly be unavailable while they restart.",
+    "warning_down_title": "This stops and removes all containers for every selected stack",
+    "warning_down_body": "Volumes are kept, but any state outside of them (e.g. in-memory caches) is lost. The stacks will disappear from the list until brought back up.",
+    "warning_kill_title": "This forcefully terminates every container in every selected stack",
+    "warning_kill_body": "Kill sends SIGKILL immediately — unlike Stop, processes get no chance to clean up or flush data. Use only when Stop does not respond.",
+    "stacks_label": "Affected stacks:",
+    "confirm_button_up": "Up",
+    "confirm_button_pull": "Pull",
+    "confirm_button_restart": "Restart",
+    "confirm_button_down": "Down",
+    "confirm_button_kill": "Kill"
   }
 }

--- a/src/lib/backgroundActions.test.ts
+++ b/src/lib/backgroundActions.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockSpawn } from "../test/setup";
+import { mockProcess } from "../test/helpers";
+import { buildUpStarter, buildPullStarter, buildDownStarter, buildRestartStarter, buildKillStarter } from "./backgroundActions";
+import type { ComposeStack } from "../api";
+
+const stack: ComposeStack = { Name: "myapp", Status: "running(1)", ConfigFiles: "/path/compose.yml" };
+
+beforeEach(() => {
+  mockSpawn.mockReset();
+  // First call in each starter resolves the superuser/profile-reading setup calls
+  mockSpawn.mockReturnValue(mockProcess(""));
+});
+
+describe("buildUpStarter", () => {
+  it("launches upStackStream with the given profiles once superuser resolves", async () => {
+    const starter = buildUpStarter(stack, ["dev"]);
+    const launch = vi.fn();
+    await starter(launch);
+    expect(launch).toHaveBeenCalledOnce();
+    const args = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1][0] as string[];
+    expect(args).toContain("up");
+    expect(args).toContain("myapp");
+    expect(args).toContain("--profile");
+    expect(args).toContain("dev");
+  });
+});
+
+describe("buildPullStarter", () => {
+  it("launches pullStack after resolving superuser and reading profiles", async () => {
+    const starter = buildPullStarter(stack);
+    const launch = vi.fn();
+    await starter(launch);
+    expect(launch).toHaveBeenCalledOnce();
+    const args = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1][0] as string[];
+    expect(args).toContain("pull");
+    expect(args).toContain("myapp");
+  });
+});
+
+describe("buildDownStarter", () => {
+  it("launches downStack once superuser resolves", async () => {
+    const starter = buildDownStarter(stack);
+    const launch = vi.fn();
+    await starter(launch);
+    expect(launch).toHaveBeenCalledOnce();
+    const args = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1][0] as string[];
+    expect(args).toContain("down");
+    expect(args).toContain("myapp");
+  });
+});
+
+describe("buildRestartStarter", () => {
+  it("launches restartStack once superuser resolves", async () => {
+    const starter = buildRestartStarter(stack);
+    const launch = vi.fn();
+    await starter(launch);
+    expect(launch).toHaveBeenCalledOnce();
+    const args = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1][0] as string[];
+    expect(args).toContain("restart");
+    expect(args).toContain("myapp");
+  });
+});
+
+describe("buildKillStarter", () => {
+  it("launches killStack once superuser resolves", async () => {
+    const starter = buildKillStarter(stack);
+    const launch = vi.fn();
+    await starter(launch);
+    expect(launch).toHaveBeenCalledOnce();
+    const killCall = mockSpawn.mock.calls.find(call => (call[0] as string[]).includes("kill"));
+    expect(killCall).toBeTruthy();
+    expect((killCall![0] as string[])).toContain("myapp");
+  });
+});

--- a/src/lib/backgroundActions.ts
+++ b/src/lib/backgroundActions.ts
@@ -1,0 +1,60 @@
+import {
+  type ComposeStack,
+  upStackStream,
+  pullStack,
+  downStack,
+  restartStack,
+  killStack,
+  composeFileSuperuser,
+  isRootlessMode,
+  readAllProfiles,
+} from "../api";
+import { splitConfigFiles } from "./configFiles";
+
+type Launch = (proc: CockpitProcess) => void;
+
+/** Resolves superuser, skipping the check entirely in rootless mode (no escalation possible/needed). */
+function resolveSuperuser(configFiles: string[]): Promise<"try" | undefined> {
+  return isRootlessMode() ? Promise.resolve(undefined) : composeFileSuperuser(configFiles);
+}
+
+/**
+ * Builds a background-task starter for `up`, given the stack and (already
+ * confirmed) profiles to activate. Shared between the single-stack "Run in
+ * Background" buttons (UpModal) and the bulk-action path.
+ */
+export function buildUpStarter(stack: ComposeStack, profiles: string[] = []) {
+  const configFiles = splitConfigFiles(stack.ConfigFiles);
+  return (launch: Launch) => resolveSuperuser(configFiles)
+    .then(su => { launch(upStackStream(stack.Name, configFiles, profiles, su)); });
+}
+
+/** Builds a background-task starter for `pull`, resolving the stack's profiles itself. */
+export function buildPullStarter(stack: ComposeStack) {
+  const configFiles = splitConfigFiles(stack.ConfigFiles);
+  return (launch: Launch) => Promise.all([
+    resolveSuperuser(configFiles),
+    readAllProfiles(configFiles[0]),
+  ]).then(([su, profiles]) => { launch(pullStack(stack.Name, configFiles, profiles, su)); });
+}
+
+/** Builds a background-task starter for `down`. */
+export function buildDownStarter(stack: ComposeStack) {
+  const configFiles = splitConfigFiles(stack.ConfigFiles);
+  return (launch: Launch) => resolveSuperuser(configFiles)
+    .then(su => { launch(downStack(stack.Name, configFiles, [], su)); });
+}
+
+/** Builds a background-task starter for `restart`. */
+export function buildRestartStarter(stack: ComposeStack) {
+  const configFiles = splitConfigFiles(stack.ConfigFiles);
+  return (launch: Launch) => resolveSuperuser(configFiles)
+    .then(su => { launch(restartStack(stack.Name, configFiles, [], [], su)); });
+}
+
+/** Builds a background-task starter for `kill`. */
+export function buildKillStarter(stack: ComposeStack) {
+  const configFiles = splitConfigFiles(stack.ConfigFiles);
+  return (launch: Launch) => resolveSuperuser(configFiles)
+    .then(su => { launch(killStack(stack.Name, configFiles, [], su)); });
+}


### PR DESCRIPTION
Add a checkbox/select-toggle to every layout (poweruser, minimal, pretty, unix), progressively revealed on hover or once any row is selected to avoid cluttering the default view, matching each layout's own aesthetic. A bulk action bar appears once at least one stack is selected, mirroring each action's row-level icon/tooltip (Up stays a primary text button; Pull/Restart/Down/Kill are icon-only). Confirming opens a summary modal listing the affected stacks with an appropriate warning (a small note for Up/Restart, a prominent danger alert for the destructive Down/Kill), then enqueues one background task per stack via the #185 queue.

Extracted the per-action background-task starter logic (previously duplicated inline in UpModal/PullModal) into lib/backgroundActions.ts, reused by both the single-stack "Run in Background" buttons and this bulk path, and extended with restart/kill starters.

Also fixes two correctness issues found while wiring this up:
- Background tasks drawer: NotificationDrawer defaults to height:100%, which doesn't resolve against a max-height parent, so content just got clipped instead of scrolling; the newest task now also scrolls into view and gets focused when the panel opens.
- Selecting stacks and switching the docker/podman runtime now clears the selection and cancels pending (not-yet-started) background tasks: a pending task's closure calls compose()/cli(), which read the live runtime at execution time, so it would otherwise run against the wrong backend once it started. Already-running or finished tasks are unaffected, since their command already ran under the correct runtime.

closes #186 

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
