### PR TITLE
feat: remember previously used Run/Exec commands

### DIFF
--- a/src/components/ExecModal.test.tsx
+++ b/src/components/ExecModal.test.tsx
@@ -61,6 +61,7 @@ beforeEach(() => {
   MockFitAddon.mockClear();
   mockFitInstance.fit.mockClear();
   vi.stubGlobal("cockpit", { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) });
+  try { localStorage.clear(); } catch { /* some tests in this file unstub globals, including the localStorage polyfill */ }
 });
 
 describe("ExecModal", () => {
@@ -124,7 +125,7 @@ describe("ExecModal", () => {
     mockSpawn.mockReturnValue(mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
-    const select = screen.getByRole("combobox");
+    const select = screen.getByRole("combobox", { name: /service/i });
     fireEvent.change(select, { target: { value: "db" } });
     // No crash — selectedService updated to "db"
     expect(screen.getByRole("option", { name: "db" })).toBeInTheDocument();
@@ -396,5 +397,49 @@ describe("ExecModal", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     vi.unstubAllGlobals();
     vi.stubGlobal("cockpit", { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) });
+  });
+
+  describe("command history", () => {
+    // Other tests in this file call vi.unstubAllGlobals(), which permanently strips the
+    // shared setup's localStorage polyfill for the rest of the file's test run (jsdom has
+    // no native localStorage here — it only exists because setup.ts stubs it once). Provide
+    // a self-contained fake so these tests don't depend on file-wide execution order.
+    beforeEach(() => {
+      const store = new Map<string, string>();
+      vi.stubGlobal("localStorage", {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => { store.set(k, v); },
+        removeItem: (k: string) => { store.delete(k); },
+        clear: () => { store.clear(); },
+      });
+    });
+
+    it("wires the command field to a datalist for browser-native suggestions", async () => {
+      mockSpawn.mockReturnValue(mockProcess(""));
+      render(<ExecModal stack={stack} onClose={vi.fn()} />);
+      const input = screen.getByLabelText(/Command/i) as HTMLInputElement;
+      expect(input.getAttribute("list")).toBeTruthy();
+      await act(async () => {});
+    });
+
+    it("records the command on launch, and it appears as a suggestion in a freshly mounted modal", async () => {
+      vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
+      vi.stubGlobal("cockpit", { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) });
+      mockSpawn.mockReturnValue(mockProcess(composeYaml));
+      const { unmount } = render(<ExecModal stack={stack} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByRole("option", { name: "web" }));
+      fireEvent.change(screen.getByLabelText(/Command/i), { target: { value: "/bin/bash" } });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Open shell/i }));
+      });
+      unmount();
+
+      mockSpawn.mockReturnValue(mockProcess(""));
+      render(<ExecModal stack={stack} onClose={vi.fn()} />);
+      const input = screen.getByLabelText(/Command/i);
+      const listId = input.getAttribute("list")!;
+      const option = document.querySelector(`#${listId} option[value="/bin/bash"]`);
+      expect(option).not.toBeNull();
+    });
   });
 });

--- a/src/components/ExecModal.tsx
+++ b/src/components/ExecModal.tsx
@@ -24,6 +24,8 @@ import {
 import "./ExecModal.css";
 import { splitConfigFiles } from "../lib/configFiles";
 import { tokenizeCommand } from "../lib/commandTokenize";
+import { useInputHistory } from "../hooks/useInputHistory";
+import { HistoryDatalist } from "./HistoryDatalist";
 
 interface Props {
   stack: ComposeStack;
@@ -48,6 +50,7 @@ export function ExecModal({ stack, onClose }: Props) {
   const [selectedService, setSelectedService] = useState("");
   const [shell, setShell] = useState("/bin/sh");
   const [user, setUser] = useState("");
+  const { history: commandHistory, record: recordCommand } = useInputHistory("exec-command");
   const [step, setStep] = useState<"config" | "terminal">("config");
   const [connectError, setConnectError] = useState<string | null>(null);
   const [fontSize, setFontSize] = useState<number>(() => {
@@ -94,6 +97,7 @@ export function ExecModal({ stack, onClose }: Props) {
     const service = selectedService.trim();
     if (!service) return;
 
+    recordCommand(shell);
     setConnectError(null);
     setStep("terminal");
 
@@ -150,7 +154,7 @@ export function ExecModal({ stack, onClose }: Props) {
         channelRef.current?.send(data);
       });
     });
-  }, [selectedService, shell, user, fontSize, stack.Name, stack.ConfigFiles, configFile]);
+  }, [selectedService, shell, user, fontSize, stack.Name, stack.ConfigFiles, configFile, recordCommand]);
 
   const disconnect = useCallback(() => {
     channelRef.current?.close();
@@ -204,7 +208,9 @@ export function ExecModal({ stack, onClose }: Props) {
                 value={shell}
                 onChange={(_e, v) => setShell(v)}
                 placeholder={t("exec_modal.field_command_placeholder")}
+                list="em2-shell-history"
               />
+              <HistoryDatalist id="em2-shell-history" history={commandHistory} />
             </FormGroup>
 
             <FormGroup label={t("exec_modal.field_user")} fieldId="em2-user">

--- a/src/components/HistoryDatalist.test.tsx
+++ b/src/components/HistoryDatalist.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { HistoryDatalist } from "./HistoryDatalist";
+
+describe("HistoryDatalist", () => {
+  it("renders a datalist with the given id", () => {
+    const { container } = render(<HistoryDatalist id="rm-history" history={[]} />);
+    expect(container.querySelector("datalist#rm-history")).toBeInTheDocument();
+  });
+
+  it("renders one option per history entry", () => {
+    const { container } = render(<HistoryDatalist id="rm-history" history={["a", "b", "c"]} />);
+    const options = container.querySelectorAll("option");
+    expect(options).toHaveLength(3);
+    expect([...options].map(o => o.value)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/components/HistoryDatalist.tsx
+++ b/src/components/HistoryDatalist.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  id: string;
+  history: string[];
+}
+
+/** Renders a native `<datalist>` for a text input's `list` attribute, giving free browser-native suggestions. */
+export function HistoryDatalist({ id, history }: Props) {
+  return (
+    <datalist id={id}>
+      {history.map(value => <option key={value} value={value} />)}
+    </datalist>
+  );
+}

--- a/src/components/RunModal.test.tsx
+++ b/src/components/RunModal.test.tsx
@@ -21,6 +21,7 @@ services:
 
 beforeEach(() => {
   mockSpawn.mockReset();
+  localStorage.clear();
 });
 
 describe("RunModal", () => {
@@ -112,8 +113,8 @@ describe("RunModal", () => {
       mockSpawn.mockReturnValue(mockProcess(composeYaml));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => screen.getByRole("option", { name: "db" }));
-      fireEvent.change(screen.getByRole("combobox"), { target: { value: "db" } });
-      const select = screen.getByRole("combobox") as HTMLSelectElement;
+      fireEvent.change(screen.getByRole("combobox", { name: /service/i }), { target: { value: "db" } });
+      const select = screen.getByRole("combobox", { name: /service/i }) as HTMLSelectElement;
       expect(select.value).toBe("db");
     });
 
@@ -275,6 +276,40 @@ describe("RunModal", () => {
       const entrypointIdx = args.indexOf("--entrypoint");
       expect(args[entrypointIdx + 1]).toBe("/app/mybin");
       expect(args).toContain("an arg with spaces");
+    });
+  });
+
+  describe("command history", () => {
+    it("wires the command field to a datalist for browser-native suggestions", async () => {
+      mockSpawn.mockReturnValue(mockProcess(""));
+      render(<RunModal stack={stack} onClose={vi.fn()} />);
+      const input = screen.getByLabelText(/Command/i) as HTMLInputElement;
+      expect(input.getAttribute("list")).toBeTruthy();
+      await act(async () => {});
+    });
+
+    it("records the command on Run, and it appears as a suggestion in a freshly mounted modal", async () => {
+      mockSpawn
+        .mockReturnValueOnce(mockProcess(composeYaml))
+        .mockReturnValueOnce(mockProcess(""))
+        .mockImplementationOnce(() => mockProcess(""));
+      const { unmount } = render(<RunModal stack={stack} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByRole("option", { name: "web" }));
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText(/Command/i), { target: { value: "echo hello" } });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /^Run$/i }));
+      });
+      await act(async () => {});
+      unmount();
+
+      mockSpawn.mockReturnValue(mockProcess(""));
+      render(<RunModal stack={stack} onClose={vi.fn()} />);
+      const input = screen.getByLabelText(/Command/i);
+      const listId = input.getAttribute("list")!;
+      const option = document.querySelector(`#${listId} option[value="echo hello"]`);
+      expect(option).not.toBeNull();
     });
   });
 });

--- a/src/components/RunModal.tsx
+++ b/src/components/RunModal.tsx
@@ -27,6 +27,8 @@ import { stripAnsi, classifyLine, type LineEntry } from "../lib/pullParser";
 import "./RunModal.css";
 import { splitConfigFiles } from "../lib/configFiles";
 import { tokenizeCommand } from "../lib/commandTokenize";
+import { useInputHistory } from "../hooks/useInputHistory";
+import { HistoryDatalist } from "./HistoryDatalist";
 
 interface Props {
   stack: ComposeStack;
@@ -43,6 +45,7 @@ export function RunModal({ stack, onClose }: Props) {
   const [command, setCommand] = useState("");
   const [removeContainer, setRemoveContainer] = useState(true);
   const [overrideEntrypoint, setOverrideEntrypoint] = useState(false);
+  const { history: commandHistory, record: recordCommand } = useInputHistory("run-command");
   const [step, setStep] = useState<"config" | "running">("config");
   const [lines, setLines] = useState<LineEntry[]>([]);
   const [done, setDone] = useState(false);
@@ -74,6 +77,7 @@ export function RunModal({ stack, onClose }: Props) {
     const cmd = command.trim();
     if (!service || !cmd) return;
 
+    recordCommand(cmd);
     setStep("running");
     const files = splitConfigFiles(stack.ConfigFiles);
     const [su, preRunIds] = await Promise.all([
@@ -112,7 +116,7 @@ export function RunModal({ stack, onClose }: Props) {
         }
         procRef.current = null;
       });
-  }, [selectedService, command, removeContainer, overrideEntrypoint, stack.Name, stack.ConfigFiles]);
+  }, [selectedService, command, removeContainer, overrideEntrypoint, stack.Name, stack.ConfigFiles, recordCommand]);
 
   const handleClose = useCallback(() => {
     procRef.current?.close();
@@ -167,7 +171,9 @@ export function RunModal({ stack, onClose }: Props) {
                 value={command}
                 onChange={(_e, v) => setCommand(v)}
                 placeholder={t("run_modal.field_command_placeholder")}
+                list="rm-command-history"
               />
+              <HistoryDatalist id="rm-command-history" history={commandHistory} />
               <div className="rm-command-help">
                 {overrideEntrypoint ? t("run_modal.field_command_help_override") : t("run_modal.field_command_help_args")}
               </div>

--- a/src/hooks/useInputHistory.test.ts
+++ b/src/hooks/useInputHistory.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useInputHistory } from "./useInputHistory";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useInputHistory", () => {
+  it("starts empty when nothing is stored", () => {
+    const { result } = renderHook(() => useInputHistory("run-command"));
+    expect(result.current.history).toEqual([]);
+  });
+
+  it("record() adds a value to the front of history", () => {
+    const { result } = renderHook(() => useInputHistory("run-command"));
+    act(() => { result.current.record("echo hello"); });
+    expect(result.current.history).toEqual(["echo hello"]);
+  });
+
+  it("newer entries appear before older ones", () => {
+    const { result } = renderHook(() => useInputHistory("run-command"));
+    act(() => { result.current.record("first"); });
+    act(() => { result.current.record("second"); });
+    expect(result.current.history).toEqual(["second", "first"]);
+  });
+
+  it("re-recording an existing value moves it to the front instead of duplicating it", () => {
+    const { result } = renderHook(() => useInputHistory("run-command"));
+    act(() => { result.current.record("a"); });
+    act(() => { result.current.record("b"); });
+    act(() => { result.current.record("a"); });
+    expect(result.current.history).toEqual(["a", "b"]);
+  });
+
+  it("ignores blank/whitespace-only values", () => {
+    const { result } = renderHook(() => useInputHistory("run-command"));
+    act(() => { result.current.record("   "); });
+    expect(result.current.history).toEqual([]);
+  });
+
+  it("trims values before storing", () => {
+    const { result } = renderHook(() => useInputHistory("run-command"));
+    act(() => { result.current.record("  echo hi  "); });
+    expect(result.current.history).toEqual(["echo hi"]);
+  });
+
+  it("caps history at the given max, dropping the oldest entries", () => {
+    const { result } = renderHook(() => useInputHistory("run-command", 2));
+    act(() => { result.current.record("a"); });
+    act(() => { result.current.record("b"); });
+    act(() => { result.current.record("c"); });
+    expect(result.current.history).toEqual(["c", "b"]);
+  });
+
+  it("persists to localStorage under a namespaced key and is read back by a new hook instance", () => {
+    const { result } = renderHook(() => useInputHistory("run-command"));
+    act(() => { result.current.record("echo hi"); });
+
+    expect(JSON.parse(localStorage.getItem("cockpit-compose:history:run-command")!)).toEqual(["echo hi"]);
+
+    const { result: result2 } = renderHook(() => useInputHistory("run-command"));
+    expect(result2.current.history).toEqual(["echo hi"]);
+  });
+
+  it("keeps separate histories for different storage keys", () => {
+    const { result: runResult } = renderHook(() => useInputHistory("run-command"));
+    const { result: execResult } = renderHook(() => useInputHistory("exec-command"));
+    act(() => { runResult.current.record("run value"); });
+    expect(runResult.current.history).toEqual(["run value"]);
+    expect(execResult.current.history).toEqual([]);
+  });
+});

--- a/src/hooks/useInputHistory.ts
+++ b/src/hooks/useInputHistory.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from "react";
+
+const STORAGE_PREFIX = "cockpit-compose:history:";
+
+function readHistory(key: string): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + key);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Tracks a small, browser-local history of previously used values for a free-text
+ * field (e.g. Run/Exec command inputs), backed by localStorage under a namespaced
+ * key. Entirely client-side — no Cockpit API involved.
+ */
+export function useInputHistory(storageKey: string, max = 20) {
+  const [history, setHistory] = useState<string[]>(() => readHistory(storageKey));
+
+  const record = useCallback((value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setHistory(prev => {
+      const next = [trimmed, ...prev.filter(v => v !== trimmed)].slice(0, max);
+      try {
+        localStorage.setItem(STORAGE_PREFIX + storageKey, JSON.stringify(next));
+      } catch { /* localStorage unavailable (e.g. private browsing quota) — history just won't persist */ }
+      return next;
+    });
+  }, [storageKey, max]);
+
+  return { history, record };
+}


### PR DESCRIPTION
Add a small browser-local history for the Run and Exec modals' free-text command fields, backed by localStorage. Uses a native <input list> + <datalist> pairing so suggestions come from the browser's own UI (arrow keys, filter-as-you-type) with no extra dependency. History records on submit/launch, not on every keystroke, so it reflects commands that were actually used.

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
