### PR TITLE
docs: document secret scanning and push protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Pull requests are welcome. Please make sure your changes pass CI (lint, typechec
 
 Found a security vulnerability? Please report it privately — see [SECURITY.md](SECURITY.md) for the disclosure process. Do not open a public issue for security reports.
 
+This repository has GitHub secret scanning and push protection enabled — do not commit secrets (API keys, tokens, passwords, `.env` files with real credentials, etc.). See [SECURITY.md](SECURITY.md) for the bypass process if a push is blocked by mistake.
+
 ## License
 
 MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,4 +44,22 @@ issue quickly:
 - Once a fix is available, we will coordinate a disclosure timeline with you and
   credit you for the report unless you prefer to remain anonymous.
 
+## Secret Scanning and Push Protection
+
+This repository has **GitHub secret scanning** and **push protection** enabled.
+Push protection blocks pushes that contain patterns matching known secret
+formats (API keys, tokens, credentials, etc.) before they ever reach the
+remote history.
+
+If a push is blocked and you believe the detected pattern is a false positive
+(e.g. test fixture data, an example credential, or a non-sensitive value),
+follow GitHub's [push protection bypass
+guide](https://docs.github.com/en/code-security/secret-scanning/working-with-secret-scanning-and-push-protection/working-with-push-protection-from-the-command-line)
+to resolve it from the command line, or use the bypass option presented in the
+GitHub UI and select the reason that matches your case (test data, false
+positive, etc.). Bypassed pushes are still logged for maintainers to review.
+
+If you ever discover a secret that was committed before scanning was enabled,
+please report it using the process above rather than opening a public issue.
+
 Thank you for helping keep `cockpit-compose` and its users safe.


### PR DESCRIPTION
## Summary
Settings-level secret scanning and push protection are already enabled (confirmed by repo owner). This PR closes the remaining documentation gap from #202.

## Changes
- `SECURITY.md`: added a "Secret Scanning and Push Protection" section explaining what push protection blocks and how to resolve a false positive (links to GitHub's push protection bypass guide).
- `README.md`: added a one-line note under **Security** stating secret scanning/push protection are active and secrets must not be committed.

## Acceptance criteria (from #202)
- [x] Secret scanning and push protection are both enabled (done outside this PR, per repo settings).
- [x] Bypass process is documented.

Closes #202