### PR TITLE
docs: document background tasks, bulk actions, and recent fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ Docker and Podman Compose management for [Cockpit](https://cockpit-project.org) 
 
 - Dashboard listing all stacks with live status and container stats (auto-refreshing)
 - Search and filter stacks by name and status
+- Select multiple stacks and run Up, Restart, Pull, Down, or Kill on all of them at once
+- Send long-running actions (Up, Pull) to the background and keep working, tracked in a floating panel
 - Create new Compose Stacks or import existing ones directly from the WebUI
 - Start, stop, restart, pause/unpause, pull, prune, scale, and kill stacks with one click
 - Live log viewer per stack with per-service filtering and text search
-- Interactive shell into any running service
+- Interactive shell into any running service, with quote-aware command parsing and command history
+- Run one-off commands with an option to override the image's entrypoint when needed
 - YAML editor with syntax validation, diff view, auto-snapshot + .ENV editor
 - Backup and restore stacks as `.bak.tar.gz` archives
-- Docker and Podman support
+- Docker and Podman support, including rootless setups
 
 ## Requirements
 

--- a/docs/wiki/Background-Tasks.md
+++ b/docs/wiki/Background-Tasks.md
@@ -1,0 +1,82 @@
+# Background Tasks
+
+Long-running actions like **Up** and **Pull** can be sent to the background instead of making you wait in front of a progress modal. Background tasks run one at a time and are tracked in a small floating panel so you can check on them, stop them, or dismiss them whenever you like.
+
+## Sending a task to the background
+
+While an **Up** or **Pull** modal is streaming output, click **Run in Background** next to **Cancel**:
+
+```
+┌──────────────────────────────────────────┐
+│  Up — myapp                        [✕]  │
+├──────────────────────────────────────────┤
+│  ● Starting myapp…                       │
+├──────────────────────────────────────────┤
+│  Container myapp-web-1  Starting         │
+│  ...                                     │
+├──────────────────────────────────────────┤
+│           [Run in Background]  [Cancel]  │
+└──────────────────────────────────────────┘
+```
+
+The modal closes immediately and the same action keeps running behind the scenes.
+
+Bulk actions (see [Bulk Actions](Bulk-Actions)) always run as background tasks — there is no foreground modal for them.
+
+## The background tasks panel
+
+A floating button appears in the bottom-right corner of the screen whenever the plugin is loaded. It shows a badge with the number of pending + running tasks:
+
+```
+                                          ┌───┐
+                                          │ 2 │
+                                          └───┘
+                                           (☰)
+```
+
+Click it to open the panel:
+
+```
+┌────────────────────────────────────┐
+│  Background tasks              [✕] │
+├────────────────────────────────────┤
+│  Up — myapp              Running   │
+│                          [Stop]    │
+├────────────────────────────────────┤
+│  Pull — otherapp          Pending  │
+├────────────────────────────────────┤
+│  Down — old-stack         Complete │
+│                          [Remove]  │
+└────────────────────────────────────┘
+```
+
+The panel is scrollable and caps its height at half the screen. Newest tasks appear at the bottom, closest to the toggle button. Opening the panel (or a new task starting) automatically scrolls to and focuses the newest entry.
+
+### Task states
+
+| State | Meaning |
+|---|---|
+| **Pending** | Queued, waiting for the currently running task to finish |
+| **Running** | Currently executing |
+| **Complete** | Finished successfully |
+| **Failed** | Finished with an error — the error message is shown under the task |
+| **Stopped** | Cancelled via the **Stop** button |
+
+Only **one task runs at a time**, in the order it was queued. This avoids two actions on the same (or a related) stack running concurrently and stepping on each other.
+
+### Controls
+
+| Button | Available when | Effect |
+|---|---|---|
+| **Stop** | Running | Closes the underlying process. The task ends up in the **Stopped** state. |
+| **Remove** | Pending, Complete, Failed, or Stopped | Removes the task from the panel. A pending task removed this way never actually runs. |
+
+### Viewing live output
+
+Click anywhere on a **Running** or **Pending** task's row to reopen its log — the same streaming output view you'd see in the foreground modal, with a **Stop** button. Finished tasks don't reopen a log view; their outcome is already visible in the panel.
+
+## Switching Docker/Podman while tasks are queued
+
+If you switch the runtime toggle (see [Podman Compatibility](Podman-Compatibility)) while tasks are still **pending**, those pending tasks are automatically cancelled instead of running against the newly selected runtime. A toast notification confirms how many were cancelled.
+
+This is intentional: a pending task doesn't build its command until it actually starts, so if it started after the switch it would run against the wrong Docker/Podman backend. Tasks that are already **Running** or have already finished are unaffected — their command was already dispatched under the runtime that was active at the time.

--- a/docs/wiki/Bulk-Actions.md
+++ b/docs/wiki/Bulk-Actions.md
@@ -1,0 +1,84 @@
+# Bulk Actions
+
+Select multiple stacks at once and run the same action (Up, Pull, Restart, Down, or Kill) across all of them in one confirmation, instead of repeating the action stack-by-stack.
+
+## Selecting stacks
+
+Every [layout](Stacks-Dashboard#layout-options) has a small checkbox (or, in the Unix layout, a `[ ]` / `[x]` toggle) for selecting a stack. To keep the default view uncluttered, the checkbox is hidden until you either:
+
+- hover over (or focus) a stack row/card, or
+- have already selected at least one other stack — once one row is checked, all the checkboxes become visible.
+
+| Layout | Selection control |
+|---|---|
+| **Power User** | Checkbox at the start of the row |
+| **Minimal** | Checkbox in the top-left corner of the card |
+| **Pretty** | Checkbox in the top-left corner of the card |
+| **Unix** | `[ ]` / `[x]` bracket toggle alongside the other `[key]` actions |
+
+Clicking a checkbox never triggers the row/card's own click-to-expand behavior.
+
+## The bulk action bar
+
+Once at least one stack is selected, a bulk action bar appears in the dashboard toolbar:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  2 selected   [Up]  (↻)  (⇩)  (⛔)   [Clear selection ✕] │
+└──────────────────────────────────────────────────────────┘
+```
+
+| Control | Action |
+|---|---|
+| **Up** (primary button, same color as the row-level Up button) | Bring all selected stacks up |
+| **↻ Restart** | Restart all selected stacks |
+| **⇩ Pull** | Pull the latest images for all selected stacks |
+| **⛔ Down** (red) | Stop and remove all selected stacks |
+| **⛔ Kill** (red) | Force-kill all selected stacks |
+| **✕ Clear selection** | Deselect everything without running an action |
+
+Each icon button shows the same tooltip text as its single-stack counterpart on the stack row.
+
+## Confirmation modal
+
+Clicking a bulk action opens a confirmation modal listing every affected stack:
+
+```
+┌──────────────────────────────────────────┐
+│  Down 2 stacks?                    [✕]  │
+├──────────────────────────────────────────┤
+│  ⚠ This stops and removes all            │
+│    containers for every selected stack   │
+│    Volumes are kept, but any state       │
+│    outside of them is lost...            │
+│                                          │
+│  ℹ This will run as background tasks.    │
+│    You can monitor, stop, or remove      │
+│    them from the background tasks panel. │
+│                                          │
+│  Affected stacks:                        │
+│   • myapp                                │
+│   • otherapp                             │
+├──────────────────────────────────────────┤
+│                    [Down]  [Cancel]      │
+└──────────────────────────────────────────┘
+```
+
+The warning shown depends on the action:
+
+| Action | Warning |
+|---|---|
+| **Up** | A small note that this might restart containers and pull new images if configuration changed |
+| **Restart** | A small note that services will briefly be unavailable |
+| **Down** | A prominent danger alert explaining containers are stopped and removed |
+| **Kill** | A prominent danger alert explaining this sends SIGKILL immediately, with no chance for containers to clean up |
+
+## Execution
+
+Confirming enqueues **one background task per selected stack** into the same queue used by [Background Tasks](Background-Tasks) — they don't run all at once, and you can track, stop, or remove each one individually from the background tasks panel. The selection is cleared and the confirmation modal closes as soon as you confirm.
+
+## Notes
+
+- Restart, Down, and Kill run for every selected stack regardless of its current state — check the confirmation list before proceeding if you have a mixed selection.
+- Prune is not available as a bulk action, since it requires choosing per-stack which resource types (images, volumes, networks) to remove — use the single-stack [Prune Resources](Prune-Resources) flow instead.
+- Switching the selected layout does not clear your selection; switching the Docker/Podman runtime does (see [Podman Compatibility](Podman-Compatibility)).

--- a/docs/wiki/Creating-Stacks.md
+++ b/docs/wiki/Creating-Stacks.md
@@ -32,7 +32,7 @@ Click the **Create** button in the **Stopped / offline stacks** section at the b
 | Field | Description |
 |---|---|
 | **Stack name** | The name for your new stack. Must not contain spaces or slashes. This becomes the Compose project name and the folder name under the root directory. |
-| **Compose root directory** | The parent directory where the new stack folder will be created. For example, if you enter `/etc/docker/compose` and a stack name of `myapp`, the file will be created at `/etc/docker/compose/myapp/docker-compose.yml`. |
+| **Compose root directory** | The parent directory where the new stack folder will be created. For example, if you enter `/etc/docker/compose` and a stack name of `myapp`, the file will be created at `/etc/docker/compose/myapp/docker-compose.yml`. If you have existing stacks, this is pre-filled based on where they're stored. Otherwise, it defaults to `/etc/docker/compose` — or, if you're running rootless Docker/Podman (see [Podman Compatibility](Podman-Compatibility)), to `<your home directory>/compose`, since `/etc` typically isn't writable without root. |
 | **Best match** button | Automatically suggests a root directory based on where your other active stacks are stored. Useful if all your stacks share a common parent directory. |
 | **Creation method** | How the compose file content will be generated — see the three options below. |
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -22,6 +22,9 @@ Cockpit Compose is a web-based UI for managing [Docker Compose](https://docs.doc
 - Works with rootless Docker automatically — no configuration needed
 - Choose between four layout styles for the stack list (Minimal, Power User, Pretty, Unix)
 - Start, stop, restart, or view logs for individual services directly from the expanded stack row
+- Select multiple stacks and run Up, Restart, Pull, Down, or Kill on all of them at once
+- Send long-running actions (Up, Pull) to the background and keep working, tracked in a floating panel
+- Suggested commands from your history when using Run or Shell
 
 ## Pages
 
@@ -29,6 +32,8 @@ Cockpit Compose is a web-based UI for managing [Docker Compose](https://docs.doc
 |---|---|
 | [Stacks Dashboard](Stacks-Dashboard) | The main screen — stack list, status indicators, stats, and action buttons |
 | [Managing Stacks](Managing-Stacks) | Up, Start, Stop, Down, Restart, Pause / Unpause, Kill |
+| [Bulk Actions](Bulk-Actions) | Select multiple stacks and run one action across all of them |
+| [Background Tasks](Background-Tasks) | Send long-running actions to the background and track them in a floating panel |
 | [Viewing Logs](Viewing-Logs) | Streaming logs with service filter and search |
 | [Editing Configuration](Editing-Configuration) | YAML editor, multi-file tabs, diff view, snapshots, env file editor |
 | [Stack Info](Stack-Info) | Containers, images, volumes, and networks |

--- a/docs/wiki/Managing-Stacks.md
+++ b/docs/wiki/Managing-Stacks.md
@@ -2,6 +2,8 @@
 
 This page covers all the lifecycle actions you can perform on a stack: bringing it up, stopping it, starting it, taking it down, restarting it, pausing it, and killing it.
 
+> **Working with multiple stacks?** Select more than one stack and run Up, Restart, Pull, Down, or Kill on all of them at once — see [Bulk Actions](Bulk-Actions).
+
 ## Up
 
 **What it does:** Runs `docker compose up -d`. Docker creates or recreates containers as needed, applies configuration changes, and leaves everything running in the background.
@@ -25,7 +27,7 @@ A progress modal opens and streams the output of `docker compose up` in real tim
 - **✓ Up complete** — all containers started successfully
 - **✗ Up failed** — an error occurred; the full error is shown below the status
 
-Click **Close** when done. If the operation is still running, click **Cancel** to abort it.
+Click **Close** when done. If the operation is still running, click **Cancel** to abort it. Alternatively, click **Run in Background** to close the modal and keep the operation running — see [Background Tasks](Background-Tasks).
 
 ---
 

--- a/docs/wiki/Podman-Compatibility.md
+++ b/docs/wiki/Podman-Compatibility.md
@@ -10,6 +10,8 @@ The selected runtime is saved in the browser and persists across sessions.
 
 If Docker is not installed when the plugin loads, it automatically prompts you to switch to Podman.
 
+Switching runtimes also clears your current stack selection and cancels any [background tasks](Background-Tasks) that haven't started running yet, since they would otherwise execute against the newly selected runtime instead of the one they were queued under.
+
 ## What changes in Podman mode
 
 - All compose commands (`up`, `down`, `logs`, `pull`, etc.) are routed through `podman compose` instead of `docker compose`.
@@ -27,6 +29,8 @@ systemctl --user enable --now podman.socket
 ```
 
 The plugin detects the user socket automatically when Podman mode is active. No additional configuration is needed.
+
+When creating your first stack in rootless mode, the suggested compose root directory defaults to `<your home directory>/compose` instead of `/etc/docker/compose`, since `/etc` typically isn't writable without root — see [Creating Stacks](Creating-Stacks).
 
 ## Supported compose providers
 

--- a/docs/wiki/Pulling-Images.md
+++ b/docs/wiki/Pulling-Images.md
@@ -51,7 +51,9 @@ When the operation finishes:
 - **✓ Pull complete** — all images were pulled or were already up to date
 - **✗ Pull failed** — an error occurred; the error is shown below the status
 
-Click **Close** when done. Click **Cancel** to abort a pull that is still in progress.
+Click **Close** when done. Click **Cancel** to abort a pull that is still in progress. Alternatively, click **Run in Background** to close the modal and keep the pull running — see [Background Tasks](Background-Tasks).
+
+> **Pulling for multiple stacks at once?** Select several stacks and use the bulk **Pull** action — see [Bulk Actions](Bulk-Actions).
 
 ## Applying pulled images
 

--- a/docs/wiki/Running-Commands.md
+++ b/docs/wiki/Running-Commands.md
@@ -14,6 +14,9 @@ Click the **⋮ more** menu on any running stack row, then select **Run**.
 ├──────────────────────────────────────────────────┤
 │  Service   [web ▼]                               │
 │  Command   [python manage.py migrate  ]          │
+│  Runs as arguments to the image's entrypoint     │
+│  (e.g. type "--help").                           │
+│  [ ] Override entrypoint                         │
 │  [✓] Remove container when done                  │
 ├──────────────────────────────────────────────────┤
 │                         [Run]  [Cancel]          │
@@ -23,10 +26,13 @@ Click the **⋮ more** menu on any running stack row, then select **Run**.
 | Field | Description |
 |---|---|
 | **Service** | The service whose image will be used to run the command. If services can be detected from the compose file, a dropdown is shown; otherwise type the service name manually. |
-| **Command** | The command to run inside the container. Multiple words are split on whitespace and passed as separate arguments (e.g., `python manage.py migrate` becomes `python`, `manage.py`, `migrate`). |
+| **Command** | The command to run inside the container. Quoted arguments are respected (e.g. `sh -c "echo foo bar"` keeps `echo foo bar` together as one argument) — previously this only split on whitespace. Suggests previously used commands via your browser's native autocomplete. |
+| **Override entrypoint** | Unchecked by default: the command runs as arguments appended after the image's own `ENTRYPOINT` — this is what makes typing just `--help` work. Check this if you want to run an arbitrary command instead, exactly as typed — for example, the full path to a binary, the same way you would with `docker exec`. This does **not** wrap your command in a shell, so it works even on minimal/distroless images that have no `/bin/sh`. |
 | **Remove container when done** | Checked by default. Passes `--rm` to `docker compose run`, so the container is automatically removed after the command exits. Uncheck if you need to inspect the container after it finishes. |
 
 Click **Run** to start. The button is disabled until both **Service** and **Command** are filled in.
+
+> **Why "Override entrypoint" exists:** `docker compose run` only replaces a container's `CMD`, not its `ENTRYPOINT`. If an image's entrypoint is already the binary you want to run (common for single-purpose images), typing that binary's own path in **Command** — the way you would with `docker exec` — collides with the entrypoint and fails with an error like `unknown command "/app/mybinary" for "mybinary"`. Checking **Override entrypoint** runs your command as-is instead of appending it to the existing entrypoint, avoiding the collision.
 
 ## Output
 

--- a/docs/wiki/Shell-Access.md
+++ b/docs/wiki/Shell-Access.md
@@ -25,7 +25,7 @@ Before the terminal opens, you configure how to connect:
 | Field | Description |
 |---|---|
 | **Service** | The service you want to connect to. If services are detected from the compose file, a dropdown is shown. Otherwise, type the service name manually. |
-| **Command** | The shell to launch inside the container. Defaults to `/bin/sh`, which works in almost all images. Change to `/bin/bash` if you prefer bash and it is installed. |
+| **Command** | The shell to launch inside the container. Defaults to `/bin/sh`, which works in almost all images. Change to `/bin/bash` if you prefer bash and it is installed. Quoted arguments are respected (e.g. `sh -c "echo foo bar"` keeps `echo foo bar` together as one argument). Suggests previously used commands via your browser's native autocomplete. |
 | **User (optional)** | Run the shell as this user. Leave empty to use the container's default user. Enter `root` to run as root. |
 
 Click **Open shell** to connect. The button is disabled if no service name has been entered.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -6,6 +6,8 @@
 
 - [Stacks Dashboard](Stacks-Dashboard)
 - [Managing Stacks](Managing-Stacks)
+- [Bulk Actions](Bulk-Actions)
+- [Background Tasks](Background-Tasks)
 - [Viewing Logs](Viewing-Logs)
 - [Editing Configuration](Editing-Configuration)
 - [Stack Info](Stack-Info)


### PR DESCRIPTION
Adds two new wiki pages (auto-synced to the GitHub wiki on merge):
- Background Tasks: the run-in-background queue, floating panel, task states/controls, and runtime-switch cancellation behavior.
- Bulk Actions: multi-select across all four layouts, the bulk action bar, and the per-action confirmation warnings.

Updates existing pages for changes since the last release:
- Running Commands / Shell Access: the "Override entrypoint" toggle and why it exists, quote-aware command parsing (no more naive whitespace split), and command history suggestions.
- Managing Stacks / Pulling Images: cross-links to the new Background Tasks and Bulk Actions pages.
- Creating Stacks / Podman Compatibility: the rootless compose-root directory default (~/compose instead of /etc/docker/compose).

Also updates the README feature list and the wiki Home page/sidebar to surface all of the above.

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [ ] CI passes (lint, typecheck, tests, build)
- [ ] Tests added or updated (if applicable)
- [ ] Manually tested in Cockpit (if UI change)
