### PR TITLE
feat: enable CodeQL scanning and dependency review

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,11 @@ on:
     # Run weekly on Mondays at 08:00 UTC to catch newly published CVEs
     - cron: "0 8 * * 1"
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   codeql:
     uses: RXTX4816/cockpit-plugin-base-react/.github/workflows/codeql-plugin.yml@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,15 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Mondays at 08:00 UTC to catch newly published CVEs
+    - cron: "0 8 * * 1"
+
+jobs:
+  codeql:
+    uses: RXTX4816/cockpit-plugin-base-react/.github/workflows/codeql-plugin.yml@main
+    secrets: inherit

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   dependency-review:
     uses: RXTX4816/cockpit-plugin-base-react/.github/workflows/dependency-review-plugin.yml@main

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,10 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  dependency-review:
+    uses: RXTX4816/cockpit-plugin-base-react/.github/workflows/dependency-review-plugin.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
Part 2 of RXTX4816/cockpit-plugin-base-react#52 — wires this repo up to the reusable CodeQL and dependency-review workflows added in base PR #69 (merged).

## Changes
- `codeql.yml`: calls `codeql-plugin.yml@main`, runs on push/PR to main plus a weekly schedule.
- `dependency-review.yml`: calls `dependency-review-plugin.yml@main`, runs on PRs to main. No local config file needed — uses the reusable workflow's default license allowlist.

## Acceptance criteria (from base #52)
- [x] CodeQL alerts will surface in this repo's Security tab.
- [x] Dependency review will block PRs that introduce high/critical CVEs or non-permissive licenses.

Refs RXTX4816/cockpit-plugin-base-react#52