### PR TITLE
fix: replace selection checkboxes with glow-based selection

### DIFF
--- a/src/components/StacksView/ContainerTable.css
+++ b/src/components/StacksView/ContainerTable.css
@@ -8,7 +8,7 @@
 
 .ct-header {
   display: grid;
-  grid-template-columns: 7rem 10rem 1fr auto auto;
+  grid-template-columns: 7rem 10rem 1fr 3rem auto;
   gap: 0.75rem;
   padding: 0.2rem 0 0.35rem;
   font-size: var(--pf-t--global--font--size--sm);
@@ -20,7 +20,7 @@
 
 .ct-row {
   display: grid;
-  grid-template-columns: 7rem 10rem 1fr auto auto;
+  grid-template-columns: 7rem 10rem 1fr 3rem auto;
   gap: 0.75rem;
   align-items: center;
   padding: 0.35rem 0.4rem;

--- a/src/components/StacksView/ContainerTable.test.tsx
+++ b/src/components/StacksView/ContainerTable.test.tsx
@@ -35,9 +35,11 @@ describe("ContainerTable", () => {
     expect(screen.getByText("nginx:latest")).toBeInTheDocument();
   });
 
-  it("renders the status text", () => {
+  it("renders a shortened uptime with the full status as a tooltip title", () => {
     render(<ContainerTable containers={[runningContainer]} />);
-    expect(screen.getByText("Up 2 hours")).toBeInTheDocument();
+    const uptime = screen.getByText("2h");
+    expect(uptime).toBeInTheDocument();
+    expect(uptime).toHaveAttribute("title", "Up 2 hours");
   });
 
   it("renders multiple containers", () => {

--- a/src/components/StacksView/ContainerTable.tsx
+++ b/src/components/StacksView/ContainerTable.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Badge, Button, Label, Spinner } from "@patternfly/react-core";
 import { Tooltip } from "@rxtx4816/cockpit-plugin-base-react/components";
 import { CheckCircleIcon, ExclamationTriangleIcon, InProgressIcon, BanIcon, PlayIcon, RedoAltIcon, ListAltIcon } from "@patternfly/react-icons";
-import type { ComposeContainer } from "../../api";
+import { parseShortUptime, type ComposeContainer } from "../../api";
 import { getImageChangelogUrl } from "../../lib/imageUrl";
 import { ExternalLinkModal } from "../ExternalLinkModal";
 import "./ContainerTable.css";
@@ -103,7 +103,7 @@ export function ContainerTable({
                 {anyHealthy && <HealthIcon health="healthy" />}
               </span>
               <span className="ct-image">{rep?.Image}</span>
-              <span className="ct-uptime">{rep?.Status}</span>
+              <span className="ct-uptime" title={rep?.Status}>{rep?.Status ? parseShortUptime(rep.Status) : rep?.Status}</span>
               {actions && (
                 <span className="ct-actions">
                   {isActing

--- a/src/components/StacksView/MinimalCard.css
+++ b/src/components/StacksView/MinimalCard.css
@@ -31,6 +31,12 @@
   box-shadow: 0 3px 12px rgba(0, 0, 0, 0.13);
 }
 
+.mc-card--selected,
+.mc-card--selected:hover,
+.mc-card--selected.mc-card--open {
+  box-shadow: 0 0 0 2px var(--pf-t--global--color--brand--default, #06c), 0 4px 16px rgba(0, 102, 204, 0.28);
+}
+
 /* Kebab in top-right — ghost until card hovered */
 .mc-kebab {
   position: absolute;
@@ -43,23 +49,6 @@
 
 .mc-card:hover .mc-kebab,
 .mc-card:focus-within .mc-kebab {
-  opacity: 1;
-}
-
-/* Select checkbox in top-left — ghost until card hovered, any card selected, or checked */
-.mc-select {
-  position: absolute;
-  top: 0.2rem;
-  left: 0.3rem;
-  z-index: 10;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-  cursor: pointer;
-}
-
-.mc-card:hover .mc-select,
-.mc-card:focus-within .mc-select,
-.mc-select--visible {
   opacity: 1;
 }
 
@@ -162,22 +151,10 @@
   border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
   border-radius: var(--pf-t--global--border--radius--md, 6px);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18), 0 2px 8px rgba(0, 0, 0, 0.10);
-  min-width: 340px;
-  max-width: 500px;
+  min-width: 480px;
+  max-width: 620px;
   max-height: 350px;
   overflow: auto;
-}
-
-.mc-bubble::after {
-  content: "";
-  position: absolute;
-  bottom: -9px;
-  left: 50%;
-  transform: translateX(-50%);
-  border-left: 9px solid transparent;
-  border-right: 9px solid transparent;
-  border-top: 9px solid var(--pf-t--global--background--color--primary--default, #fff);
-  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.08));
 }
 
 .mc-bubble-title {

--- a/src/components/StacksView/MinimalCard.test.tsx
+++ b/src/components/StacksView/MinimalCard.test.tsx
@@ -255,19 +255,29 @@ describe("MinimalCard", () => {
   });
 
   describe("selection", () => {
-    it("does not render a checkbox when onToggleSelect is not provided", () => {
+    it("does not toggle selection when clicking the card if onToggleSelect is not provided", () => {
       render(<MinimalCard {...defaultProps} />);
-      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      const card = screen.getByRole("button", { name: "myapp — running" });
+      expect(card).not.toHaveAttribute("aria-pressed");
+      fireEvent.click(card);
+      // no error, no-op
     });
 
-    it("renders a checkbox reflecting isSelected and calls onToggleSelect on click, without opening the container bubble", () => {
+    it("reflects isSelected via aria-pressed and the selected class, and toggles selection when the card is clicked", () => {
       const onToggleSelect = vi.fn();
       render(<MinimalCard {...defaultProps} onToggleSelect={onToggleSelect} isSelected />);
-      const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
-      expect(checkbox.checked).toBe(true);
-      fireEvent.click(checkbox);
+      const card = screen.getByRole("button", { name: "myapp — running" });
+      expect(card).toHaveAttribute("aria-pressed", "true");
+      expect(card).toHaveClass("mc-card--selected");
+      fireEvent.click(card);
       expect(onToggleSelect).toHaveBeenCalledOnce();
-      expect(screen.queryByText(/no containers/i)).not.toBeInTheDocument();
+    });
+
+    it("does not toggle selection when clicking the kebab menu toggle", () => {
+      const onToggleSelect = vi.fn();
+      render(<MinimalCard {...defaultProps} onToggleSelect={onToggleSelect} />);
+      fireEvent.click(screen.getByRole("button", { name: /more actions/i }));
+      expect(onToggleSelect).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/StacksView/MinimalCard.tsx
+++ b/src/components/StacksView/MinimalCard.tsx
@@ -45,6 +45,9 @@ import { LogsModal } from "../LogsModal";
 import { splitConfigFiles } from "../../lib/configFiles";
 import "./MinimalCard.css";
 
+const BUBBLE_OPEN_DELAY_MS = 400;
+const BUBBLE_CLOSE_DELAY_MS = 25;
+
 interface MinimalCardProps {
   stack: ComposeStack;
   expanded: boolean;
@@ -66,7 +69,6 @@ interface MinimalCardProps {
   onActingChange: (delta: 1 | -1) => void;
   isSelected?: boolean;
   onToggleSelect?: () => void;
-  anySelected?: boolean;
 }
 
 const STATUS_VARS: Record<string, { bg: string; border: string }> = {
@@ -80,13 +82,15 @@ const STATUS_VARS: Record<string, { bg: string; border: string }> = {
 export function MinimalCard({
   stack, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull,
   onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange,
-  isSelected = false, onToggleSelect, anySelected = false,
+  isSelected = false, onToggleSelect,
 }: MinimalCardProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmStopOpen, setConfirmStopOpen] = useState(false);
-  const [bubble, setBubble] = useState<{ x: number; y: number } | null>(null);
-  const bubbleRef = useRef<HTMLDivElement>(null);
+  const [bubblePos, setBubblePos] = useState<{ left: number; top: number } | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const openTimerRef = useRef<number | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
 
   const baseStatus = parseStackStatus(stack.Status);
   const count = parseServiceCount(stack.Status);
@@ -107,36 +111,48 @@ export function MinimalCard({
   useEffect(() => { void loadContainers(); }, [loadContainers]);
   useAutoRefresh(loadContainers, acting ? 500 : 3000, false);
 
-  useEffect(() => {
-    if (!bubble) return;
-    const handler = (e: globalThis.MouseEvent) => {
-      if (bubbleRef.current && !bubbleRef.current.contains(e.target as HTMLElement)) {
-        setBubble(null);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [bubble]);
-
-  const handleCardClick = (e: MouseEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLElement;
-    if (target.closest("button, input, [role=button], .pf-v6-c-dropdown")) return;
-    if (bubble) {
-      setBubble(null);
-    } else {
-      setBubble({ x: e.clientX, y: e.clientY });
-      void loadContainers();
+  const clearOpenTimer = () => {
+    if (openTimerRef.current !== null) {
+      window.clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
     }
   };
+  const clearCloseTimer = () => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+  const scheduleBubbleClose = () => {
+    clearOpenTimer();
+    clearCloseTimer();
+    closeTimerRef.current = window.setTimeout(() => setBubblePos(null), BUBBLE_CLOSE_DELAY_MS);
+  };
+  const showBubble = () => {
+    const rect = cardRef.current?.getBoundingClientRect();
+    if (rect) {
+      const W = 560, H = 320;
+      const vw = window.innerWidth;
+      let left = rect.left + rect.width / 2 - W / 2;
+      const top = rect.top - H - 8 < 8 ? rect.bottom + 8 : rect.top - H - 8;
+      if (left < 8) left = 8;
+      if (left + W > vw - 8) left = vw - W - 8;
+      setBubblePos({ left, top });
+    }
+    void loadContainers();
+  };
+  const scheduleBubbleOpen = () => {
+    clearCloseTimer();
+    clearOpenTimer();
+    openTimerRef.current = window.setTimeout(showBubble, BUBBLE_OPEN_DELAY_MS);
+  };
+  useEffect(() => () => { clearOpenTimer(); clearCloseTimer(); }, []);
 
-  const getBubblePos = (x: number, y: number) => {
-    const W = 380, H = 320;
-    const vw = window.innerWidth;
-    let left = x - W / 2;
-    const top = y - H - 12 < 8 ? y + 12 : y - H - 12;
-    if (left < 8) left = 8;
-    if (left + W > vw - 8) left = vw - W - 8;
-    return { left, top };
+  const handleCardClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (!onToggleSelect) return;
+    const target = e.target as HTMLElement;
+    if (target.closest("button, input, .pf-v6-c-dropdown")) return;
+    onToggleSelect();
   };
 
   const isUp = status === "running" || status === "partial" || status === "paused";
@@ -145,26 +161,20 @@ export function MinimalCard({
   return (
     <>
       <div
-        className={`mc-card${acting ? " mc-card--acting" : ""}${bubble ? " mc-card--open" : ""}`}
+        ref={cardRef}
+        className={`mc-card${acting ? " mc-card--acting" : ""}${isSelected ? " mc-card--selected" : ""}${bubblePos ? " mc-card--open" : ""}`}
         style={{ backgroundColor: sv.bg, borderColor: sv.border }}
         data-status={status}
         data-stack-name={stack.Name}
         onClick={handleCardClick}
+        onMouseEnter={scheduleBubbleOpen}
+        onMouseLeave={scheduleBubbleClose}
         role="button"
         tabIndex={0}
+        aria-pressed={onToggleSelect ? isSelected : undefined}
         aria-label={`${stack.Name} — ${status}`}
         onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") handleCardClick(e as unknown as MouseEvent<HTMLDivElement>); }}
       >
-        {onToggleSelect && (
-          <input
-            type="checkbox"
-            className={`mc-select${anySelected ? " mc-select--visible" : ""}`}
-            checked={isSelected}
-            onChange={onToggleSelect}
-            onClick={(e) => e.stopPropagation()}
-            aria-label={t("stacks.select_stack", { name: stack.Name })}
-          />
-        )}
         <div className="mc-kebab" onClick={(e) => e.stopPropagation()}>
           <Dropdown
             isOpen={menuOpen}
@@ -275,11 +285,12 @@ export function MinimalCard({
         </Modal>
       )}
 
-      {bubble && (
+      {bubblePos && (
         <div
-          ref={bubbleRef}
           className="mc-bubble"
-          style={getBubblePos(bubble.x, bubble.y)}
+          style={bubblePos}
+          onMouseEnter={clearCloseTimer}
+          onMouseLeave={scheduleBubbleClose}
           onClick={(e) => e.stopPropagation()}
         >
           {loadingContainers ? (

--- a/src/components/StacksView/PrettyCard.css
+++ b/src/components/StacksView/PrettyCard.css
@@ -10,11 +10,17 @@
   flex-direction: column;
   break-inside: avoid;
   margin-bottom: 0.875rem;
+  cursor: pointer;
 }
 
 .pc-card:hover {
   box-shadow: 0 6px 22px var(--status-glow, rgba(0, 0, 0, 0.10));
   transform: translateY(-2px);
+}
+
+.pc-card--selected,
+.pc-card--selected:hover {
+  box-shadow: 0 0 0 2px var(--pf-t--global--color--brand--default, #06c), 0 6px 20px rgba(0, 102, 204, 0.30);
 }
 
 .pc-card--acting {
@@ -42,23 +48,6 @@
   0%   { box-shadow: 0 0 0 0 rgba(110, 198, 100, 0.55); }
   70%  { box-shadow: 0 0 0 7px rgba(110, 198, 100, 0); }
   100% { box-shadow: 0 0 0 0 rgba(110, 198, 100, 0); }
-}
-
-/* Select checkbox in top-left — ghost until card hovered, any card selected, or checked */
-.pc-select {
-  position: absolute;
-  top: 0.45rem;
-  left: 0.5rem;
-  z-index: 10;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-  cursor: pointer;
-}
-
-.pc-card:hover .pc-select,
-.pc-card:focus-within .pc-select,
-.pc-select--visible {
-  opacity: 1;
 }
 
 /* Header */

--- a/src/components/StacksView/PrettyCard.test.tsx
+++ b/src/components/StacksView/PrettyCard.test.tsx
@@ -303,18 +303,29 @@ describe("PrettyCard", () => {
   });
 
   describe("selection", () => {
-    it("does not render a checkbox when onToggleSelect is not provided", () => {
-      render(<PrettyCard {...defaultProps} />);
-      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    it("does not toggle selection when clicking the card if onToggleSelect is not provided", () => {
+      const { container } = render(<PrettyCard {...defaultProps} />);
+      const card = container.querySelector(".pc-card") as HTMLElement;
+      expect(card).not.toHaveAttribute("aria-pressed");
+      fireEvent.click(card);
+      // no error, no-op
     });
 
-    it("renders a checkbox reflecting isSelected and calls onToggleSelect on click", () => {
+    it("reflects isSelected via aria-pressed and the selected class, and toggles selection when the card is clicked", () => {
       const onToggleSelect = vi.fn();
-      render(<PrettyCard {...defaultProps} onToggleSelect={onToggleSelect} isSelected />);
-      const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
-      expect(checkbox.checked).toBe(true);
-      fireEvent.click(checkbox);
+      const { container } = render(<PrettyCard {...defaultProps} onToggleSelect={onToggleSelect} isSelected />);
+      const card = container.querySelector(".pc-card") as HTMLElement;
+      expect(card).toHaveAttribute("aria-pressed", "true");
+      expect(card).toHaveClass("pc-card--selected");
+      fireEvent.click(card);
       expect(onToggleSelect).toHaveBeenCalledOnce();
+    });
+
+    it("does not toggle selection when clicking the expand toggle", () => {
+      const onToggleSelect = vi.fn();
+      render(<PrettyCard {...defaultProps} onToggleSelect={onToggleSelect} />);
+      fireEvent.click(screen.getByRole("button", { name: /expand/i }));
+      expect(onToggleSelect).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/StacksView/PrettyCard.tsx
+++ b/src/components/StacksView/PrettyCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, type CSSProperties } from "react";
+import { useState, useCallback, useEffect, type CSSProperties, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -68,7 +68,6 @@ interface PrettyCardProps {
   onActingChange: (delta: 1 | -1) => void;
   isSelected?: boolean;
   onToggleSelect?: () => void;
-  anySelected?: boolean;
 }
 
 const STATUS_BORDER: Record<string, string> = {
@@ -90,7 +89,7 @@ const STATUS_GLOW: Record<string, string> = {
 export function PrettyCard({
   stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull,
   onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange,
-  isSelected = false, onToggleSelect, anySelected = false,
+  isSelected = false, onToggleSelect,
 }: PrettyCardProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -121,6 +120,14 @@ export function PrettyCard({
     if (!expanded) void loadContainers();
   };
 
+  const handleCardClick = onToggleSelect
+    ? (e: MouseEvent<HTMLDivElement>) => {
+        const target = e.target as HTMLElement;
+        if (target.closest("button, input, a, .pf-v6-c-dropdown, .pc-port-pill, .pc-expanded")) return;
+        onToggleSelect();
+      }
+    : undefined;
+
   useEffect(() => { void loadContainers(); }, [loadContainers]);
   useAutoRefresh(loadContainers, acting ? 500 : 3000, false);
 
@@ -131,25 +138,17 @@ export function PrettyCard({
   return (
     <>
       <div
-        className={`pc-card${acting ? " pc-card--acting" : ""}${expanded ? " pc-card--expanded" : ""}`}
+        className={`pc-card${acting ? " pc-card--acting" : ""}${expanded ? " pc-card--expanded" : ""}${isSelected ? " pc-card--selected" : ""}`}
         style={{
           "--status-glow": STATUS_GLOW[status],
           "--status-border": STATUS_BORDER[status] ?? STATUS_BORDER.unknown,
         } as CSSProperties}
         data-status={status}
         data-stack-name={stack.Name}
+        onClick={handleCardClick}
+        aria-pressed={onToggleSelect ? isSelected : undefined}
       >
         {status === "running" && <span className="pc-pulse" />}
-
-        {onToggleSelect && (
-          <input
-            type="checkbox"
-            className={`pc-select${anySelected ? " pc-select--visible" : ""}`}
-            checked={isSelected}
-            onChange={onToggleSelect}
-            aria-label={t("stacks.select_stack", { name: stack.Name })}
-          />
-        )}
 
         {/* Header */}
         <div className="pc-header">

--- a/src/components/StacksView/StackRow.css
+++ b/src/components/StacksView/StackRow.css
@@ -9,6 +9,18 @@
   opacity: 1;
 }
 
+.sr-check .pf-v6-c-check__input {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--pf-t--global--color--brand--default, #06c);
+  cursor: pointer;
+}
+
+.sr-row--selected {
+  box-shadow: inset 0 0 0 2px var(--pf-t--global--color--brand--default, #06c), 0 0 14px rgba(0, 102, 204, 0.22);
+  background: rgba(0, 102, 204, 0.06);
+}
+
 .sr-name-cell {
   display: flex;
   align-items: center;

--- a/src/components/StacksView/StackRow.tsx
+++ b/src/components/StacksView/StackRow.tsx
@@ -127,7 +127,7 @@ export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, on
   return (
     <>
     <DataListItem isExpanded={expanded} aria-labelledby={`stack-${stack.Name}`} data-status={status} data-stack-name={stack.Name}>
-      <DataListItemRow onClick={handleRowClick} style={{ cursor: "pointer" }}>
+      <DataListItemRow onClick={handleRowClick} style={{ cursor: "pointer" }} className={isSelected ? "sr-row--selected" : undefined}>
         {onToggleSelect && (
           <DataListCheck
             aria-labelledby={`stack-${stack.Name}`}

--- a/src/components/StacksView/index.tsx
+++ b/src/components/StacksView/index.tsx
@@ -469,7 +469,6 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onActingChange={onActingChange}
               isSelected={selected.has(stack.Name)}
               onToggleSelect={() => toggleSelect(stack.Name)}
-              anySelected={selected.size > 0}
             />
           ))}
         </div>
@@ -498,7 +497,6 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onActingChange={onActingChange}
               isSelected={selected.has(stack.Name)}
               onToggleSelect={() => toggleSelect(stack.Name)}
-              anySelected={selected.size > 0}
             />
           ))}
         </div>


### PR DESCRIPTION
Minimal and pretty layouts now toggle selection by clicking anywhere on the tile (excluding action controls) and show a brand-colored glow ring instead of a checkbox overlay. Power-user's checkbox is restyled and the whole row now glows when selected; unix keeps its existing toggle style.

Also restores minimal's container-info popover on hover (previously broken by a self-matching role="button" click-exclusion bug) and fixes the container table's uptime column crowding out the actions column for long-running containers.

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
