### PR TITLE
fix: resolve open CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/check-base-updates.yml
+++ b/.github/workflows/check-base-updates.yml
@@ -3,6 +3,10 @@ name: Check for base package updates
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-base-updates:
     uses: RXTX4816/cockpit-plugin-base-react/.github/workflows/check-base-updates-plugin.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: RXTX4816/cockpit-plugin-base-react/.github/workflows/ci-plugin.yml@main

--- a/.github/workflows/pkg-ci.yml
+++ b/.github/workflows/pkg-ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pkg-ci:
     uses: RXTX4816/cockpit-plugin-base-react/.github/workflows/pkg-ci-plugin.yml@main

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "docs/wiki/**"
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     uses: RXTX4816/cockpit-plugin-base-react/.github/workflows/sync-wiki-plugin.yml@main

--- a/src/components/CreateStackModal.test.tsx
+++ b/src/components/CreateStackModal.test.tsx
@@ -352,7 +352,7 @@ describe("CreateStackModal — step 2 git url", () => {
   it("shows URL input and Fetch button", async () => {
     render(<CreateStackModal {...defaultProps} />);
     await fillSetupAndAdvance("git");
-    expect(screen.getByPlaceholderText(/github.com/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/^https:\/\/github\.com\//i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Fetch/i })).toBeInTheDocument();
   });
 
@@ -371,7 +371,7 @@ describe("CreateStackModal — step 2 git url", () => {
   it("rejects non-https URL without cloning", async () => {
     render(<CreateStackModal {...defaultProps} />);
     await fillSetupAndAdvance("git");
-    fireEvent.change(screen.getByPlaceholderText(/github.com/i), {
+    fireEvent.change(screen.getByPlaceholderText(/^https:\/\/github\.com\//i), {
       target: { value: "file:///etc/passwd" },
     });
     await act(async () => {
@@ -386,7 +386,7 @@ describe("CreateStackModal — step 2 git url", () => {
   it("rejects non-URL string without cloning", async () => {
     render(<CreateStackModal {...defaultProps} />);
     await fillSetupAndAdvance("git");
-    fireEvent.change(screen.getByPlaceholderText(/github.com/i), {
+    fireEvent.change(screen.getByPlaceholderText(/^https:\/\/github\.com\//i), {
       target: { value: "../../../etc/passwd" },
     });
     await act(async () => {
@@ -406,7 +406,7 @@ describe("CreateStackModal — step 2 git url", () => {
 
     render(<CreateStackModal {...defaultProps} />);
     await fillSetupAndAdvance("git");
-    fireEvent.change(screen.getByPlaceholderText(/github.com/i), {
+    fireEvent.change(screen.getByPlaceholderText(/^https:\/\/github\.com\//i), {
       target: { value: "https://example.com/repo.git" },
     });
     await act(async () => {
@@ -425,7 +425,7 @@ describe("CreateStackModal — step 2 git url", () => {
 
     render(<CreateStackModal {...defaultProps} />);
     await fillSetupAndAdvance("git");
-    fireEvent.change(screen.getByPlaceholderText(/github.com/i), {
+    fireEvent.change(screen.getByPlaceholderText(/^https:\/\/github\.com\//i), {
       target: { value: "https://example.com/repo.git" },
     });
     await act(async () => {
@@ -442,7 +442,7 @@ describe("CreateStackModal — step 2 git url", () => {
 
     render(<CreateStackModal {...defaultProps} />);
     await fillSetupAndAdvance("git");
-    fireEvent.change(screen.getByPlaceholderText(/github.com/i), {
+    fireEvent.change(screen.getByPlaceholderText(/^https:\/\/github\.com\//i), {
       target: { value: "https://example.com/repo.git" },
     });
     await act(async () => {
@@ -462,7 +462,7 @@ describe("CreateStackModal — step 2 git url", () => {
     const onCreated = vi.fn();
     render(<CreateStackModal {...defaultProps} onCreated={onCreated} />);
     await fillSetupAndAdvance("git");
-    fireEvent.change(screen.getByPlaceholderText(/github.com/i), {
+    fireEvent.change(screen.getByPlaceholderText(/^https:\/\/github\.com\//i), {
       target: { value: "https://example.com/repo.git" },
     });
     await act(async () => {


### PR DESCRIPTION
Add least-privilege permissions blocks to the four workflows that lacked them, and anchor/escape the placeholder-matching regex in CreateStackModal.test.tsx to satisfy the missing-regexp-anchor check.

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] Chore / Refactor

## Testing

- [ ] CI passes (lint, typecheck, tests, build)
- [ ] Tests added or updated (if applicable)
- [ ] Manually tested in Cockpit (if UI change)
