### PR TITLE
Migrate App.tsx root component to PluginPage (#212)

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { Page, PageSection } from "@patternfly/react-core";
+import { PluginPage } from "@rxtx4816/cockpit-plugin-base-react/components";
 import { useLayout } from "@rxtx4816/cockpit-plugin-base-react";
 import { AppFooter } from "./AppFooter";
 import { StacksView } from "./StacksView";
 import { ErrorBoundary } from "./ErrorBoundary";
-import { ToastProvider } from "./ToastProvider";
 import { BackgroundTasksProvider } from "../hooks/useBackgroundTasks";
 import { BackgroundTasksDrawer } from "./BackgroundTasksDrawer";
 import { detectComposeCommand, detectDockerMode, type Runtime } from "../api";
@@ -37,25 +36,20 @@ export function App() {
   if (!ready) return null;
 
   return (
-    <ToastProvider>
-      <BackgroundTasksProvider>
-        <div data-layout={layout}>
-          <Page className="pf-m-no-sidebar">
-            <PageSection hasBodyWrapper={false} isFilled>
-              <ErrorBoundary fallbackTitle={t("error_boundary.load_stacks_error")}>
-                <StacksView
-                  onRuntimeChange={setRuntime}
-                  dockerMissing={dockerMissing}
-                  layout={layout}
-                  onLayoutChange={setLayout}
-                />
-              </ErrorBoundary>
-            </PageSection>
-            <AppFooter runtime={runtime} />
-          </Page>
-          <BackgroundTasksDrawer />
-        </div>
-      </BackgroundTasksProvider>
-    </ToastProvider>
+    <BackgroundTasksProvider>
+      <div data-layout={layout}>
+        <PluginPage footer={<AppFooter runtime={runtime} />}>
+          <ErrorBoundary fallbackTitle={t("error_boundary.load_stacks_error")}>
+            <StacksView
+              onRuntimeChange={setRuntime}
+              dockerMissing={dockerMissing}
+              layout={layout}
+              onLayoutChange={setLayout}
+            />
+          </ErrorBoundary>
+        </PluginPage>
+        <BackgroundTasksDrawer />
+      </div>
+    </BackgroundTasksProvider>
   );
 }


### PR DESCRIPTION
## Summary

- **#212**: Migrates `App.tsx` to base's `PluginPage`, using its new `footer` slot for `AppFooter` (preserving its current Page-sibling position), now that `PluginPage` supports the layout this app needs (RXTX4816/cockpit-plugin-base-react#86).
- Keeps this app's own `ErrorBoundary` scoped narrowly to `StacksView`, nested inside `PluginPage`'s children, rather than collapsing it into `PluginPage`'s app-wide boundary — additive coverage (an outer safety net around `AppFooter` etc.) without narrowing today's catch scope.
- Drops the now-redundant top-level `ToastProvider`/`Page`/`PageSection` (supplied by `PluginPage`).

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (1448 tests passing)
- [x] Verified via `yalc` against the base branch implementing #86
- [x] Manually verified: sticky footer, toasts, background-tasks drawer, layout switching, StacksView error boundary