### PR TITLE
docs: install latest release assets via curl instead of manual version lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,26 +53,27 @@ paru -S cockpit-compose
 
 ### Fedora / RHEL / CentOS Stream / openSUSE
 
-Download the `.rpm` from the [Releases](https://github.com/RXTX4816/cockpit-compose/releases) page:
+Every release publishes a `-latest.rpm` alias alongside the versioned one, so you can always grab the newest build without checking the [Releases](https://github.com/RXTX4816/cockpit-compose/releases) page for a version number:
 
 ```bash
-sudo rpm -i cockpit-compose-X.Y.Z-1.noarch.rpm
+curl -LO https://github.com/RXTX4816/cockpit-compose/releases/latest/download/cockpit-compose-latest.rpm
+sudo rpm -i cockpit-compose-latest.rpm
 ```
 
 ### Debian / Ubuntu / Linux Mint / Pop!\_OS
 
-Download the `.deb` from the [Releases](https://github.com/RXTX4816/cockpit-compose/releases) page:
-
 ```bash
-sudo apt install ./cockpit-compose_X.Y.Z-1_all.deb
+curl -LO https://github.com/RXTX4816/cockpit-compose/releases/latest/download/cockpit-compose-latest.deb
+sudo apt install ./cockpit-compose-latest.deb
 ```
 
 ### Manual
 
-Download the latest release tarball from the [Releases](https://github.com/RXTX4816/cockpit-compose/releases) page.
-
 ```bash
-tar -xzf cockpit-compose-X.Y.Z.tar.gz
+curl -LO https://github.com/RXTX4816/cockpit-compose/releases/latest/download/cockpit-compose-latest.tar.gz
+curl -LO https://github.com/RXTX4816/cockpit-compose/releases/latest/download/cockpit-compose-latest.tar.gz.sha256
+sha256sum -c cockpit-compose-latest.tar.gz.sha256
+tar -xzf cockpit-compose-latest.tar.gz
 sudo mkdir -p /usr/share/cockpit/cockpit-compose
 sudo cp -r cockpit-compose/* /usr/share/cockpit/cockpit-compose/
 ```


### PR DESCRIPTION
## Summary

The reusable release workflow (`release-plugin.yml` in base) publishes `-latest.{tar.gz,rpm,deb}` alias assets alongside every versioned release. Updates the RPM, DEB, and manual tarball install instructions to `curl` these directly (with sha256 verification for the tarball) instead of requiring users to look up the current version number on the Releases page.

## Test plan

- [x] Verified `-latest.tar.gz`/`.rpm`/`.deb` assets exist on the current release and resolve via the `/releases/latest/download/` redirect
- [x] Docs-only change, no code affected