### PR TITLE
fix(stacks): add select-all toggle to bulk selection toolbar (#216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The UI language follows Cockpit's language setting.
 | Coverage | Languages |
 |---|---|
 | 100% | English (`en`) — source |
-| 90% | `de`, `pl` |
+| 89% | `de`, `pl` |
 | 88% | `ar`, `cs`, `es`, `fi`, `fr`, `he`, `id`, `it`, `ja`, `ka`, `ko`, `nl`, `pt-BR`, `ro`, `ru`, `sk`, `sv`, `tr`, `uk`, `zh-CN`, `zh-TW` |
 <!-- i18n-coverage-end -->
 

--- a/src/components/StacksView/index.test.tsx
+++ b/src/components/StacksView/index.test.tsx
@@ -764,4 +764,48 @@ describe("StacksView — bulk selection and bulk actions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
     expect(mockEnqueue).toHaveBeenCalledWith("myapp", "kill", expect.anything(), expect.any(Function));
   });
+
+  it("selects all displayed stacks when the select-all toggle is checked", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(screen.getByTestId("sv-select-all"));
+    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("select-myapp")).toBeChecked();
+    expect(screen.getByLabelText("select-otherapp")).toBeChecked();
+  });
+
+  it("de-toggling select-all clears the selection but keeps the toolbar visible with grayed-out actions", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(screen.getByTestId("sv-select-all"));
+    fireEvent.click(screen.getByTestId("sv-select-all"));
+
+    expect(screen.getByTestId("sv-bulk-bar")).toBeInTheDocument();
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+    expect(within(screen.getByTestId("sv-bulk-bar")).getByRole("button", { name: "Up" })).toBeDisabled();
+    expect(within(screen.getByTestId("sv-bulk-bar")).getByRole("button", { name: /Restart/i })).toBeDisabled();
+  });
+
+  it("clear selection button fully hides the toolbar even after select-all was used", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(screen.getByTestId("sv-select-all"));
+    fireEvent.click(screen.getByRole("button", { name: /clear selection/i }));
+    expect(screen.queryByTestId("sv-bulk-bar")).toBeNull();
+  });
+
+  it("auto-hides the grayed-out toolbar after 5 seconds of an empty selection", () => {
+    vi.useFakeTimers();
+    try {
+      render(<StacksView />);
+      fireEvent.click(screen.getByLabelText("select-myapp"));
+      fireEvent.click(screen.getByLabelText("select-myapp"));
+      expect(screen.getByTestId("sv-bulk-bar")).toBeInTheDocument();
+
+      act(() => { vi.advanceTimersByTime(5000); });
+      expect(screen.queryByTestId("sv-bulk-bar")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/components/StacksView/index.tsx
+++ b/src/components/StacksView/index.tsx
@@ -25,6 +25,7 @@ import {
   SearchInput,
   Label,
   Spinner,
+  Checkbox,
 } from "@patternfly/react-core";
 import { Tooltip } from "@rxtx4816/cockpit-plugin-base-react/components";
 import { type ComposeStack, type Runtime } from "../../api";
@@ -115,10 +116,12 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
   ] as const;
   const modals = useDialogState<ComposeModals>(MODAL_NAMES);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [showBulkBar, setShowBulkBar] = useState(false);
   const toggleSelect = useCallback((name: string) => {
     setSelected(prev => {
       const next = new Set(prev);
       if (next.has(name)) next.delete(name); else next.add(name);
+      if (next.size > 0) setShowBulkBar(true);
       return next;
     });
   }, []);
@@ -131,6 +134,8 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
     searchTerm, setSearchTerm, activeFilters, toggleFilter,
     filteredStacks: displayedStacks, statusCounts, STATUS_FILTER_OPTIONS, clearFilters,
   } = useStackFilters(stacks);
+  const allSelected = displayedStacks.length > 0 && displayedStacks.every(s => selected.has(s.Name));
+  const someSelected = selected.size > 0 && !allSelected;
 
   useEffect(() => {
     if (searchOpen) {
@@ -142,6 +147,13 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
   useEffect(() => {
     if (searchTerm) setSearchOpen(true);
   }, [searchTerm]);
+
+  useEffect(() => {
+    if (showBulkBar && selected.size === 0) {
+      const timer = setTimeout(() => setShowBulkBar(false), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [showBulkBar, selected.size]);
 
   const onActingChange = useCallback((delta: 1 | -1) => {
     if (delta > 0) increment(); else decrement();
@@ -172,6 +184,7 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
       );
     }
     setSelected(new Set());
+    setShowBulkBar(false);
     modals.close("bulkConfirm");
   }, [modals, enqueue, t]);
 
@@ -293,13 +306,30 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
             </ToolbarItem>
           )}
 
-          {selected.size > 0 && (
+          {showBulkBar && (
             <ToolbarItem>
               <div className="sv-bulk-bar" data-testid="sv-bulk-bar">
+                <Tooltip content={t(allSelected ? "stacks.deselect_all" : "stacks.select_all")}>
+                  <Checkbox
+                    id="sv-select-all"
+                    data-testid="sv-select-all"
+                    aria-label={t(allSelected ? "stacks.deselect_all" : "stacks.select_all")}
+                    isChecked={allSelected ? true : (someSelected ? null : false)}
+                    onChange={() => {
+                      if (allSelected) {
+                        setSelected(new Set());
+                      } else {
+                        setSelected(new Set(displayedStacks.map(s => s.Name)));
+                        setShowBulkBar(true);
+                      }
+                    }}
+                  />
+                </Tooltip>
                 <span className="sv-bulk-count">{t("stacks.bulk_selected", { count: selected.size })}</span>
                 <Button
                   variant="primary"
                   size="sm"
+                  isDisabled={selected.size === 0}
                   onClick={() => modals.open("bulkConfirm", {
                     stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "up",
                   })}
@@ -311,6 +341,7 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
                     <Button
                       variant="plain"
                       size="sm"
+                      isDisabled={selected.size === 0}
                       aria-label={t("actions.restart")}
                       onClick={() => modals.open("bulkConfirm", {
                         stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "restart",
@@ -323,6 +354,7 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
                     <Button
                       variant="plain"
                       size="sm"
+                      isDisabled={selected.size === 0}
                       aria-label={t("actions.pull_title")}
                       onClick={() => modals.open("bulkConfirm", {
                         stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "pull",
@@ -336,6 +368,7 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
                       variant="plain"
                       size="sm"
                       className="sr-down-btn"
+                      isDisabled={selected.size === 0}
                       aria-label={t("actions.down_title")}
                       onClick={() => modals.open("bulkConfirm", {
                         stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "down",
@@ -348,6 +381,7 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
                     <Button
                       variant="plain"
                       size="sm"
+                      isDisabled={selected.size === 0}
                       aria-label={t("actions.kill")}
                       onClick={() => modals.open("bulkConfirm", {
                         stacks: displayedStacks.filter(s => selected.has(s.Name)), action: "kill",
@@ -362,7 +396,7 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
                     variant="plain"
                     size="sm"
                     aria-label={t("stacks.bulk_clear")}
-                    onClick={() => setSelected(new Set())}
+                    onClick={() => { setSelected(new Set()); setShowBulkBar(false); }}
                   >
                     <TimesIcon />
                   </Button>
@@ -379,6 +413,7 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
                   setRuntimeSwitchKey(k => k + 1);
                   reset();
                   setSelected(new Set());
+                  setShowBulkBar(false);
                   const cancelled = clearPending();
                   if (cancelled > 0) toast.warn(t("stacks.runtime_switch_cancelled_tasks", { count: cancelled }));
                   onRuntimeChange?.(r);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -45,6 +45,7 @@
     "filter_tooltip_paused": "Show only paused stacks",
     "select_stack": "Select {{name}}",
     "select_all": "Select all",
+    "deselect_all": "Deselect all",
     "bulk_selected": "{{count}} selected",
     "bulk_clear": "Clear selection",
     "runtime_switch_cancelled_tasks_one": "Cancelled {{count}} pending background task because the runtime changed",


### PR DESCRIPTION
Select-all is now a toggle inside the bulk action bar: activating it selects every displayed stack, and toggling it off (or manually deselecting everything) clears the selection but keeps the toolbar visible with its actions grayed out for a few seconds before it auto-hides, instead of disappearing instantly. The explicit clear (X) button still dismisses it immediately.

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
