### PR TITLE
fix(background-tasks): allow viewing logs of finished jobs (#217)

### DIFF
--- a/src/api/stacks.test.ts
+++ b/src/api/stacks.test.ts
@@ -188,6 +188,13 @@ describe("restartStack", () => {
     const args = mockSpawn.mock.calls[0][0] as string[];
     expect(args).toContain("restart");
   });
+
+  it("merges stderr into stdout (err: out)", () => {
+    mockSpawn.mockReturnValue(mockProcess(""));
+    restartStack("myapp", ["/path/compose.yml"]);
+    const opts = mockSpawn.mock.calls[0][1] as { err: string };
+    expect(opts.err).toBe("out");
+  });
 });
 
 describe("streamLogs", () => {
@@ -226,6 +233,13 @@ describe("downStack", () => {
     downStack("myapp", ["/path/base.yml", "/path/override.yml"]);
     const args = mockSpawn.mock.calls[0][0] as string[];
     expect(args.filter(a => a === "-f")).toHaveLength(2);
+  });
+
+  it("merges stderr into stdout (err: out)", () => {
+    mockSpawn.mockReturnValue(mockProcess(""));
+    downStack("myapp", ["/path/compose.yml"]);
+    const opts = mockSpawn.mock.calls[0][1] as { err: string };
+    expect(opts.err).toBe("out");
   });
 });
 

--- a/src/api/stacks.ts
+++ b/src/api/stacks.ts
@@ -106,7 +106,8 @@ export function restartStack(project: string, configFiles: string[], profiles: s
   const profileFlags = profiles.flatMap(p => ["--profile", p]);
   return cockpit.spawn(
     compose(...profileFlags, "-p", project, ...fileFlags(configFiles), "restart", ...services),
-    { superuser, err: "message", ...dockerSpawnEnviron() },
+    // err:"out" merges stderr into the streamable stdout so the log viewer gets all output
+    { superuser, err: "out", ...dockerSpawnEnviron() },
   );
 }
 
@@ -154,7 +155,8 @@ export function downStack(project: string, configFiles: string[], profiles: stri
   const profileFlags = profiles.flatMap(p => ["--profile", p]);
   return cockpit.spawn(
     compose(...profileFlags, "-p", project, ...fileFlags(configFiles), "down"),
-    { superuser, err: "message", ...dockerSpawnEnviron() },
+    // err:"out" merges stderr into the streamable stdout so the log viewer gets all output
+    { superuser, err: "out", ...dockerSpawnEnviron() },
   );
 }
 

--- a/src/components/BackgroundTasksDrawer.test.tsx
+++ b/src/components/BackgroundTasksDrawer.test.tsx
@@ -98,12 +98,25 @@ describe("BackgroundTasksDrawer", () => {
     expect(screen.queryByText(/Waiting for output/i)).not.toBeInTheDocument();
   });
 
-  it("clicking a finished task's row does not reopen a modal", () => {
-    mockTasks = [{ id: 2, stackName: "b", action: "pull", label: "Pull b", status: "success", lines: [], createdAt: 0 }];
+  it("clicking a finished task's row opens its log modal with the captured output", () => {
+    mockTasks = [{
+      id: 2, stackName: "b", action: "pull", label: "Pull b", status: "success",
+      lines: ["Pulling b-web-1  Done"], createdAt: 0,
+    }];
     render(<BackgroundTasksDrawer />);
     fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
     fireEvent.click(screen.getByText("Pull b"));
-    expect(screen.queryByText(/Waiting for output/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/Pulling b-web-1/)).toBeInTheDocument();
+  });
+
+  it("clicking Remove on a finished row does not also reopen its log modal", () => {
+    mockTasks = [{ id: 2, stackName: "b", action: "pull", label: "Pull b", status: "success", lines: [], createdAt: 0 }];
+    render(<BackgroundTasksDrawer />);
+    fireEvent.click(screen.getByRole("button", { name: /Background tasks/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Remove$/i }));
+    expect(mockRemove).toHaveBeenCalledWith(2);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("focuses the newest (last) task row when the panel opens", () => {

--- a/src/components/BackgroundTasksDrawer.tsx
+++ b/src/components/BackgroundTasksDrawer.tsx
@@ -77,13 +77,12 @@ export function BackgroundTasksDrawer() {
               ) : (
                 <NotificationDrawerList>
                   {tasks.map(task => {
-                    const clickable = task.status === "running" || task.status === "pending";
                     return (
                       <NotificationDrawerListItem
                         key={task.id}
                         variant={statusVariant(task.status)}
-                        isHoverable={clickable}
-                        onClick={clickable ? () => setOpenTask(task) : undefined}
+                        isHoverable
+                        onClick={() => setOpenTask(task)}
                       >
                         <NotificationDrawerListItemHeader
                           variant={statusVariant(task.status)}

--- a/src/components/StacksView/index.test.tsx
+++ b/src/components/StacksView/index.test.tsx
@@ -752,7 +752,7 @@ describe("StacksView — bulk selection and bulk actions", () => {
     expect(screen.getByTestId("bulk-confirm-modal")).toBeInTheDocument();
     expect(screen.getByText("restart myapp")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
-    expect(mockEnqueue).toHaveBeenCalledWith("myapp", "restart", expect.anything(), expect.any(Function));
+    expect(mockEnqueue).toHaveBeenCalledWith("myapp", "restart", expect.anything(), expect.any(Function), undefined);
   });
 
   it("supports bulk kill", () => {
@@ -762,7 +762,26 @@ describe("StacksView — bulk selection and bulk actions", () => {
     expect(screen.getByTestId("bulk-confirm-modal")).toBeInTheDocument();
     expect(screen.getByText("kill myapp")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
-    expect(mockEnqueue).toHaveBeenCalledWith("myapp", "kill", expect.anything(), expect.any(Function));
+    expect(mockEnqueue).toHaveBeenCalledWith("myapp", "kill", expect.anything(), expect.any(Function), undefined);
+  });
+
+  it("supports bulk down and adds each downed stack to DownedStacksSection once its task succeeds", () => {
+    render(<StacksView />);
+    fireEvent.click(screen.getByLabelText("select-myapp"));
+    fireEvent.click(screen.getByLabelText("select-otherapp"));
+    fireEvent.click(within(screen.getByTestId("sv-bulk-bar")).getByRole("button", { name: /Down/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(2);
+    const onSuccessMyapp = mockEnqueue.mock.calls[0][4] as () => void;
+    const onSuccessOtherapp = mockEnqueue.mock.calls[1][4] as () => void;
+    expect(onSuccessMyapp).toEqual(expect.any(Function));
+    expect(onSuccessOtherapp).toEqual(expect.any(Function));
+
+    act(() => { onSuccessMyapp(); });
+    expect(screen.getByTestId("downed-section")).toHaveTextContent("1 downed");
+    act(() => { onSuccessOtherapp(); });
+    expect(screen.getByTestId("downed-section")).toHaveTextContent("2 downed");
   });
 
   it("selects all displayed stacks when the select-all toggle is checked", () => {

--- a/src/components/StacksView/index.tsx
+++ b/src/components/StacksView/index.tsx
@@ -181,12 +181,13 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
         data.action,
         t(`${data.action}_modal.background_label`, { name: stack.Name }),
         buildStarter(stack),
+        data.action === "down" ? () => handleDownComplete(stack) : undefined,
       );
     }
     setSelected(new Set());
     setShowBulkBar(false);
     modals.close("bulkConfirm");
-  }, [modals, enqueue, t]);
+  }, [modals, enqueue, t, handleDownComplete]);
 
   const { target: downTarget, downing, error: downError, open: openDown, close: closeDown, execute: performDown }
     = useDownStack(refresh, onActingChange, handleDownComplete);

--- a/src/hooks/useBackgroundTasks.test.tsx
+++ b/src/hooks/useBackgroundTasks.test.tsx
@@ -44,6 +44,24 @@ describe("useBackgroundTasks", () => {
     expect(start).toHaveBeenCalledOnce();
   });
 
+  it("calls the optional onSuccess callback once the task settles as success, but not for a failed task", async () => {
+    const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
+    const onSuccess = vi.fn();
+    act(() => {
+      result.current.enqueue("myapp", "down", "Down myapp", launch => launch(fakeProcess("resolve")), onSuccess);
+    });
+
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("success"));
+    expect(onSuccess).toHaveBeenCalledOnce();
+
+    onSuccess.mockClear();
+    act(() => {
+      result.current.enqueue("otherapp", "down", "Down otherapp", launch => launch(fakeProcess("reject")), onSuccess);
+    });
+    await waitFor(() => expect(result.current.tasks[1].status).toBe("error"));
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
   it("a failed task ends in 'error' status with the error message", async () => {
     const { result } = renderHook(() => useBackgroundTasks(), { wrapper });
     act(() => { result.current.enqueue("myapp", "up", "Up myapp", launch => launch(fakeProcess("reject"))); });

--- a/src/hooks/useBackgroundTasks.tsx
+++ b/src/hooks/useBackgroundTasks.tsx
@@ -29,8 +29,11 @@ type TaskStarter = (launch: (proc: CockpitProcess) => void) => void | Promise<vo
 
 export interface BackgroundTasksContextValue {
   tasks: BackgroundTask[];
-  /** Enqueues a task. `start` is only invoked once the task reaches the front of the queue. */
-  enqueue: (stackName: string, action: string, label: string, start: TaskStarter) => void;
+  /**
+   * Enqueues a task. `start` is only invoked once the task reaches the front of the queue.
+   * `onSuccess`, if given, fires once the task settles with status "success".
+   */
+  enqueue: (stackName: string, action: string, label: string, start: TaskStarter, onSuccess?: () => void) => void;
   /** Closes the underlying process of a running task (or marks a not-yet-started one to stop as soon as it starts). */
   stop: (id: number) => void;
   /** Removes a task from the list. No-op while the task is still running. */
@@ -68,6 +71,7 @@ export function BackgroundTasksProvider({ children }: { children: ReactNode }) {
   const [tasks, setTasks] = useState<BackgroundTask[]>([]);
   const countersRef = useRef(0);
   const startersRef = useRef(new Map<number, TaskStarter>());
+  const onSuccessRef = useRef(new Map<number, () => void>());
   const procsRef = useRef(new Map<number, CockpitProcess>());
   const stoppedRef = useRef(new Set<number>());
   const bufsRef = useRef(new Map<number, string>());
@@ -90,8 +94,10 @@ export function BackgroundTasksProvider({ children }: { children: ReactNode }) {
       if (settledRef.current.has(next.id)) return;
       settledRef.current.add(next.id);
       setTasks(prev => prev.map(t => (t.id === next.id ? { ...t, status, errorMsg } : t)));
+      if (status === "success") onSuccessRef.current.get(next.id)?.();
       procsRef.current.delete(next.id);
       startersRef.current.delete(next.id);
+      onSuccessRef.current.delete(next.id);
       stoppedRef.current.delete(next.id);
       bufsRef.current.delete(next.id);
       settledRef.current.delete(next.id);
@@ -128,9 +134,10 @@ export function BackgroundTasksProvider({ children }: { children: ReactNode }) {
     }
   }, [tasks]);
 
-  const enqueue = useCallback((stackName: string, action: string, label: string, start: TaskStarter) => {
+  const enqueue = useCallback((stackName: string, action: string, label: string, start: TaskStarter, onSuccess?: () => void) => {
     const id = ++countersRef.current;
     startersRef.current.set(id, start);
+    if (onSuccess) onSuccessRef.current.set(id, onSuccess);
     setTasks(prev => [...prev, { id, stackName, action, label, status: "pending", lines: [], createdAt: Date.now() }]);
   }, []);
 
@@ -142,13 +149,17 @@ export function BackgroundTasksProvider({ children }: { children: ReactNode }) {
   const remove = useCallback((id: number) => {
     setTasks(prev => prev.filter(t => !(t.id === id && t.status !== "running")));
     startersRef.current.delete(id);
+    onSuccessRef.current.delete(id);
   }, []);
 
   const clearPending = useCallback((): number => {
     const pendingIds = tasks.filter(t => t.status === "pending").map(t => t.id);
     if (pendingIds.length === 0) return 0;
     setTasks(prev => prev.filter(t => t.status !== "pending"));
-    for (const id of pendingIds) startersRef.current.delete(id);
+    for (const id of pendingIds) {
+      startersRef.current.delete(id);
+      onSuccessRef.current.delete(id);
+    }
     return pendingIds.length;
   }, [tasks]);
 


### PR DESCRIPTION
Finished task rows (success/error/stopped) were excluded from the click handler that opens the log modal, even though their output was already captured in memory the whole time. Make every row clickable so past output is viewable, not just running/pending ones.

While verifying this manually, found and fixed two related bugs:

- downStack/restartStack spawned with err:"message" instead of err:"out" like up/pull, so compose's stderr progress output was discarded on success instead of streamed into the task's log lines — down/restart jobs always showed "Waiting for output..." even on success.

- Bulk-downing multiple stacks never added them to the "downed stacks" section, unlike the single-stack Down flow, because handleBulkConfirm enqueued down tasks without hooking into completion. enqueue() now accepts an optional onSuccess callback, invoked once a task settles as "success", which bulk down uses to call handleDownComplete per stack — the same callback the single-stack flow already used.

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
