### PR TITLE
fix(downed-stacks): add select-all and bulk Up to the downed stacks t…

### DIFF
--- a/src/components/DownedStacksSection.css
+++ b/src/components/DownedStacksSection.css
@@ -9,6 +9,46 @@
   margin-left: auto;
 }
 
+.dss-bulk-bar {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 0.75rem;
+  margin: 0.5rem 0;
+  background: var(--pf-t--global--background--color--secondary--default);
+  border: 1px solid var(--pf-t--global--border--color--default);
+  border-radius: var(--pf-t--global--border--radius--200);
+}
+
+.dss-mini-select {
+  margin-right: 0.25rem;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.dss-mini-select--visible,
+.dss-mini-card:hover .dss-mini-select,
+.dss-mini-select:checked {
+  opacity: 1;
+}
+
+.dss-check {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.dss-check--visible,
+.pf-v6-c-data-list__item-row:hover .dss-check,
+.pf-v6-c-data-list__item-row:focus-within .dss-check {
+  opacity: 1;
+}
+
+.dss-row--selected {
+  box-shadow: inset 0 0 0 2px var(--pf-t--global--color--brand--default, #06c), 0 0 14px rgba(0, 102, 204, 0.22);
+  background: rgba(0, 102, 204, 0.06);
+}
+
 
 .dss-controls {
   display: flex;
@@ -456,6 +496,11 @@
 .dss-pretty-card:hover {
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
   transform: translateY(-1px);
+}
+
+.dss-pretty-card--selected,
+.dss-pretty-card--selected:hover {
+  box-shadow: 0 0 0 2px var(--pf-t--global--color--brand--default, #06c), 0 6px 20px rgba(0, 102, 204, 0.30);
 }
 
 .dss-pretty-body {

--- a/src/components/DownedStacksSection.test.tsx
+++ b/src/components/DownedStacksSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { DownedStacksSection, inferComposeRoot } from "./DownedStacksSection";
 
 vi.mock("../hooks/useDownedStacksScan", () => ({
@@ -70,6 +70,24 @@ vi.mock("./GlobalPruneModal", () => ({
     </div>
   ),
 }));
+vi.mock("./BulkActionConfirmModal", () => ({
+  BulkActionConfirmModal: ({
+    stacks, action, onConfirm, onClose,
+  }: {
+    stacks: { Name: string }[]; action: string; onConfirm: () => void; onClose: () => void;
+  }) => (
+    <div data-testid="bulk-confirm-modal">
+      <span>{action} {stacks.map(s => s.Name).join(",")}</span>
+      <button onClick={onConfirm}>Confirm</button>
+      <button onClick={onClose}>Cancel</button>
+    </div>
+  ),
+}));
+
+const mockEnqueue = vi.fn();
+vi.mock("../hooks/useBackgroundTasks", () => ({
+  useBackgroundTasks: () => ({ tasks: [], enqueue: mockEnqueue, stop: vi.fn(), remove: vi.fn(), clearPending: vi.fn() }),
+}));
 
 import { useDownedStacksScan } from "../hooks/useDownedStacksScan";
 const mockUseScan = vi.mocked(useDownedStacksScan);
@@ -104,6 +122,7 @@ beforeEach(() => {
   noopRemove.mockReset();
   noopAdd.mockReset();
   noopUpdate.mockReset();
+  mockEnqueue.mockReset();
   mockUseScan.mockReturnValue(defaultScanResult());
 });
 
@@ -528,6 +547,126 @@ describe("DownedStacksSection — RestoreModal", () => {
     render(<DownedStacksSection {...defaultProps} stacks={[]} manuallyDownedStacks={manuallyDownedStacks} />);
     fireEvent.click(screen.getByRole("button", { name: /restore/i }));
     expect(screen.getByTestId("restore-modal")).toHaveAttribute("data-scandir", "/etc/docker/compose");
+  });
+});
+
+describe("DownedStacksSection — bulk select-all and bulk Up", () => {
+  const stackA = { name: "alpha", configFiles: ["/etc/compose/alpha/compose.yml"] };
+  const stackB = { name: "beta", configFiles: ["/etc/compose/beta/compose.yml"] };
+
+  beforeEach(() => {
+    mockUseScan.mockReturnValue(defaultScanResult({ downedStacks: [stackA, stackB], hasScanned: true }));
+  });
+
+  it("does not show the bulk bar when nothing is selected", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    expect(screen.queryByTestId("dss-bulk-bar")).not.toBeInTheDocument();
+  });
+
+  it("shows the bulk bar once a stack is selected", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    expect(screen.getByTestId("dss-bulk-bar")).toBeInTheDocument();
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+  });
+
+  it("select-all selects every downed stack", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByTestId("dss-select-all"));
+    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Select alpha")).toBeChecked();
+    expect(screen.getByLabelText("Select beta")).toBeChecked();
+  });
+
+  it("de-toggling select-all clears the selection but keeps the bar visible with the Up button disabled", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByTestId("dss-select-all"));
+    fireEvent.click(screen.getByTestId("dss-select-all"));
+
+    expect(screen.getByTestId("dss-bulk-bar")).toBeInTheDocument();
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+    expect(within(screen.getByTestId("dss-bulk-bar")).getByRole("button", { name: "Up" })).toBeDisabled();
+  });
+
+  it("clear selection button fully hides the bulk bar", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByRole("button", { name: /clear selection/i }));
+    expect(screen.queryByTestId("dss-bulk-bar")).not.toBeInTheDocument();
+  });
+
+  it("bulk Up opens the confirm modal, and confirming enqueues an up task per selected stack", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select beta"));
+    fireEvent.click(within(screen.getByTestId("dss-bulk-bar")).getByRole("button", { name: "Up" }));
+
+    expect(screen.getByTestId("bulk-confirm-modal")).toBeInTheDocument();
+    expect(screen.getByText("up alpha,beta")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(mockEnqueue).toHaveBeenCalledTimes(2);
+    expect(mockEnqueue.mock.calls[0][0]).toBe("alpha");
+    expect(mockEnqueue.mock.calls[0][1]).toBe("up");
+    expect(mockEnqueue.mock.calls[1][0]).toBe("beta");
+    expect(screen.queryByTestId("bulk-confirm-modal")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("dss-bulk-bar")).not.toBeInTheDocument();
+  });
+
+  it("calls removeStack/onUpComplete/onRefresh via the enqueued onSuccess callback once a bulk up task succeeds", () => {
+    const removeStack = vi.fn();
+    const onUpComplete = vi.fn();
+    const onRefresh = vi.fn();
+    mockUseScan.mockReturnValue(defaultScanResult({ downedStacks: [stackA, stackB], hasScanned: true, removeStack }));
+    render(<DownedStacksSection {...defaultProps} onUpComplete={onUpComplete} onRefresh={onRefresh} />);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(within(screen.getByTestId("dss-bulk-bar")).getByRole("button", { name: "Up" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    const onSuccess = mockEnqueue.mock.calls[0][4] as () => void;
+    onSuccess();
+    expect(removeStack).toHaveBeenCalledWith("alpha");
+    expect(onUpComplete).toHaveBeenCalledWith("alpha");
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it("cancelling the bulk confirm modal keeps the selection intact", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(within(screen.getByTestId("dss-bulk-bar")).getByRole("button", { name: "Up" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByTestId("bulk-confirm-modal")).not.toBeInTheDocument();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+  });
+
+  it("clicking a default-layout row (not a button) toggles its selection", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    fireEvent.click(screen.getByText("alpha"));
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Select alpha")).toBeChecked();
+  });
+
+  it("clicking a button within a default-layout row does not toggle its selection", () => {
+    render(<DownedStacksSection {...defaultProps} />);
+    fireEvent.click(screen.getAllByRole("button", { name: /^Up$/i })[0]);
+    expect(screen.queryByTestId("dss-bulk-bar")).not.toBeInTheDocument();
+  });
+
+  it("clicking a pretty-layout card (not a button) toggles its selection", () => {
+    mockUseScan.mockReturnValue(defaultScanResult({ downedStacks: [stackA, stackB], hasScanned: true }));
+    render(<DownedStacksSection {...defaultProps} layout="pretty" />);
+    fireEvent.click(screen.getByText("alpha"));
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+  });
+
+  it("clicking the Up button within a pretty-layout card does not toggle its selection", () => {
+    mockUseScan.mockReturnValue(defaultScanResult({ downedStacks: [stackA, stackB], hasScanned: true }));
+    render(<DownedStacksSection {...defaultProps} layout="pretty" />);
+    fireEvent.click(screen.getAllByRole("button", { name: /up/i })[0]);
+    expect(screen.queryByTestId("dss-bulk-bar")).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/DownedStacksSection.tsx
+++ b/src/components/DownedStacksSection.tsx
@@ -6,13 +6,15 @@ import {
   DataListItemRow,
   DataListItemCells,
   DataListCell,
+  DataListCheck,
   Button,
   Alert,
   Spinner,
   TextInput,
+  Checkbox,
 } from "@patternfly/react-core";
 import { Tooltip } from "@rxtx4816/cockpit-plugin-base-react/components";
-import { PlusCircleIcon, FolderOpenIcon, AngleUpIcon, HistoryIcon, PencilAltIcon, ArchiveIcon, TrashIcon, BroomIcon } from "@patternfly/react-icons";
+import { PlusCircleIcon, FolderOpenIcon, AngleUpIcon, HistoryIcon, PencilAltIcon, ArchiveIcon, TrashIcon, BroomIcon, TimesIcon } from "@patternfly/react-icons";
 import { type ComposeStack } from "../api";
 import { type DownedStack, useDownedStacksScan } from "../hooks/useDownedStacksScan";
 import { type Layout } from "../lib/layout";
@@ -24,6 +26,9 @@ import { DeleteStackModal } from "./DeleteStackModal";
 import { RestoreModal } from "./RestoreModal";
 import { BackupModal } from "./BackupModal";
 import { GlobalPruneModal } from "./GlobalPruneModal";
+import { BulkActionConfirmModal } from "./BulkActionConfirmModal";
+import { useBackgroundTasks } from "../hooks/useBackgroundTasks";
+import { buildUpStarter } from "../lib/backgroundActions";
 import "./DownedStacksSection.css";
 import "./StacksView/UnixRow.css";
 import { inferComposeRoot } from "../lib/composeDiscovery";
@@ -68,6 +73,18 @@ export function DownedStacksSection({ stacks, manuallyDownedStacks, onRefresh, o
   const [miniMenu, setMiniMenu] = useState<{ stack: DownedStack; x: number; y: number } | null>(null);
   const miniMenuRef = useRef<HTMLDivElement>(null);
   const autoDetectedRef = useRef(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [showBulkBar, setShowBulkBar] = useState(false);
+  const [bulkConfirmStacks, setBulkConfirmStacks] = useState<DownedStack[] | null>(null);
+  const { enqueue } = useBackgroundTasks();
+  const toggleSelect = useCallback((name: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      if (next.size > 0) setShowBulkBar(true);
+      return next;
+    });
+  }, []);
 
   const { downedStacks, scanning, hasScanned, error, warning, scan, removeStack, addStack, updateStack }
     = useDownedStacksScan(composeDir, maxDepth, stacks);
@@ -82,6 +99,33 @@ export function DownedStacksSection({ stacks, manuallyDownedStacks, onRefresh, o
     const override = configFileOverrides[d.name.toLowerCase()];
     return override ? { ...d, configFiles: override } : d;
   });
+
+  const allSelected = combinedStacks.length > 0 && combinedStacks.every(d => selected.has(d.name));
+  const someSelected = selected.size > 0 && !allSelected;
+
+  useEffect(() => {
+    if (showBulkBar && selected.size === 0) {
+      const timer = setTimeout(() => setShowBulkBar(false), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [showBulkBar, selected.size]);
+
+  const handleBulkUpConfirm = useCallback(() => {
+    if (!bulkConfirmStacks) return;
+    for (const d of bulkConfirmStacks) {
+      const stack = toSyntheticStack(d);
+      enqueue(
+        d.name,
+        "up",
+        t("up_modal.background_label", { name: d.name }),
+        buildUpStarter(stack, []),
+        () => { removeStack(d.name); onUpComplete(d.name); onRefresh(); },
+      );
+    }
+    setSelected(new Set());
+    setShowBulkBar(false);
+    setBulkConfirmStacks(null);
+  }, [bulkConfirmStacks, enqueue, t, removeStack, onUpComplete, onRefresh]);
 
   // Auto-detect the compose root on first stacks load
   useEffect(() => {
@@ -307,6 +351,46 @@ export function DownedStacksSection({ stacks, manuallyDownedStacks, onRefresh, o
             <span className="dss-separator-label">{t("downed_section.down_status")}</span>
           </div>
 
+          {showBulkBar && (
+            <div className="dss-bulk-bar" data-testid="dss-bulk-bar">
+              <Tooltip content={t(allSelected ? "stacks.deselect_all" : "stacks.select_all")}>
+                <Checkbox
+                  id="dss-select-all"
+                  data-testid="dss-select-all"
+                  aria-label={t(allSelected ? "stacks.deselect_all" : "stacks.select_all")}
+                  isChecked={allSelected ? true : (someSelected ? null : false)}
+                  onChange={() => {
+                    if (allSelected) {
+                      setSelected(new Set());
+                    } else {
+                      setSelected(new Set(combinedStacks.map(d => d.name)));
+                      setShowBulkBar(true);
+                    }
+                  }}
+                />
+              </Tooltip>
+              <span className="sv-bulk-count">{t("stacks.bulk_selected", { count: selected.size })}</span>
+              <Button
+                variant="primary"
+                size="sm"
+                isDisabled={selected.size === 0}
+                onClick={() => setBulkConfirmStacks(combinedStacks.filter(d => selected.has(d.name)))}
+              >
+                {t("actions.up")}
+              </Button>
+              <Tooltip content={t("stacks.bulk_clear")}>
+                <Button
+                  variant="plain"
+                  size="sm"
+                  aria-label={t("stacks.bulk_clear")}
+                  onClick={() => { setSelected(new Set()); setShowBulkBar(false); }}
+                >
+                  <TimesIcon />
+                </Button>
+              </Tooltip>
+            </div>
+          )}
+
           {scanning && (
             <div className="dss-list-wrapper dss-scanning">
               <Spinner size="sm" />
@@ -341,17 +425,25 @@ export function DownedStacksSection({ stacks, manuallyDownedStacks, onRefresh, o
                       title={d.configFiles[0] ?? ""}
                       onClick={(e) => {
                         const target = e.target as HTMLElement;
-                        if (target.closest(".dss-mini-up")) return;
+                        if (target.closest(".dss-mini-up") || target.closest(".dss-mini-select")) return;
                         e.preventDefault();
                         setMiniMenu({ stack: d, x: e.clientX, y: e.clientY });
                       }}
                       onContextMenu={(e) => {
                         const target = e.target as HTMLElement;
-                        if (target.closest(".dss-mini-up")) return;
+                        if (target.closest(".dss-mini-up") || target.closest(".dss-mini-select")) return;
                         e.preventDefault();
                         setMiniMenu({ stack: d, x: e.clientX, y: e.clientY });
                       }}
                     >
+                      <input
+                        type="checkbox"
+                        className={`dss-mini-select${selected.size > 0 ? " dss-mini-select--visible" : ""}`}
+                        aria-label={t("stacks.select_stack", { name: d.name })}
+                        checked={selected.has(d.name)}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={() => toggleSelect(d.name)}
+                      />
                       <span className="dss-mini-name">{d.name}</span>
                       <Tooltip content={t("actions.up_title")}>
                         <Button
@@ -388,7 +480,16 @@ export function DownedStacksSection({ stacks, manuallyDownedStacks, onRefresh, o
             ) : layout === "pretty" ? (
               <div className="dss-pretty-grid">
                 {combinedStacks.map(d => (
-                  <div key={d.name} className="dss-pretty-card">
+                  <div
+                    key={d.name}
+                    className={`dss-pretty-card${selected.has(d.name) ? " dss-pretty-card--selected" : ""}`}
+                    onClick={(e) => {
+                      const target = e.target as HTMLElement;
+                      if (target.closest("button, input, a")) return;
+                      toggleSelect(d.name);
+                    }}
+                    aria-pressed={selected.has(d.name)}
+                  >
                     <div className="dss-pretty-body">
                       <span className="dss-pretty-name">{d.name}</span>
                       <span className="dss-pretty-path">{d.configFiles[0]?.replace(/\/[^/]+$/, "") ?? ""}</span>
@@ -419,6 +520,14 @@ export function DownedStacksSection({ stacks, manuallyDownedStacks, onRefresh, o
                     <span className="dss-unix-name">{d.name}</span>
                     <span className="dss-unix-path" title={d.configFiles[0] ?? ""}>{d.configFiles[0]?.replace(/.*\/([^/]+\/[^/]+)$/, "$1") ?? ""}</span>
                     <div className="dss-unix-actions">
+                      <button
+                        className={`ur-key ur-key--select${selected.has(d.name) ? " ur-key--select-on" : ""}`}
+                        onClick={() => toggleSelect(d.name)}
+                        aria-pressed={selected.has(d.name)}
+                        aria-label={t("stacks.select_stack", { name: d.name })}
+                      >
+                        {selected.has(d.name) ? "[x]" : "[ ]"}
+                      </button>
                       <Tooltip content={t("actions.up_title")}>
                         <button className="ur-key ur-key--up" onClick={() => setUpConfirmTarget(d)}>[up]</button>
                       </Tooltip>
@@ -440,7 +549,22 @@ export function DownedStacksSection({ stacks, manuallyDownedStacks, onRefresh, o
                 <DataList aria-label={t("downed_section.down_stacks_aria")} isCompact className="dss-list">
                   {combinedStacks.map(d => (
                     <DataListItem key={d.name} aria-labelledby={`dss-name-${d.name}`} data-status="down">
-                      <DataListItemRow>
+                      <DataListItemRow
+                        onClick={(e) => {
+                          const target = e.target as HTMLElement;
+                          if (target.closest("button, input, select, a")) return;
+                          toggleSelect(d.name);
+                        }}
+                        style={{ cursor: "pointer" }}
+                        className={selected.has(d.name) ? "dss-row--selected" : undefined}
+                      >
+                        <DataListCheck
+                          aria-labelledby={`dss-name-${d.name}`}
+                          aria-label={t("stacks.select_stack", { name: d.name })}
+                          isChecked={selected.has(d.name)}
+                          onChange={() => toggleSelect(d.name)}
+                          className={`dss-check${selected.size > 0 ? " dss-check--visible" : ""}`}
+                        />
                         <DataListItemCells
                           dataListCells={[
                             <DataListCell key="name" width={2}>
@@ -564,6 +688,14 @@ export function DownedStacksSection({ stacks, manuallyDownedStacks, onRefresh, o
         <GlobalPruneModal
           onClose={() => setPruneOpen(false)}
           onSuccess={onRefresh}
+        />
+      )}
+      {bulkConfirmStacks && (
+        <BulkActionConfirmModal
+          stacks={bulkConfirmStacks.map(toSyntheticStack)}
+          action="up"
+          onConfirm={handleBulkUpConfirm}
+          onClose={() => setBulkConfirmStacks(null)}
         />
       )}
     </>


### PR DESCRIPTION
…able (#220)

Reuses the same selection-toolbar pattern added to the main stacks table (#216): a select-all toggle that stays visible with its action grayed out once the selection empties instead of disappearing, and an explicit clear button. Since a down stack only supports being brought back up, the bulk bar exposes a single Up action, reusing BulkActionConfirmModal and the background-task queue the main table's bulk actions already use — including the onSuccess hook (added in #217) to update the downed-stacks list once each task completes.

Per-row selection follows each layout's own conventions: a hover/selection-revealed checkbox for the default (DataList) and minimal layouts, click-to-select-with-glow on the whole tile for pretty (matching the main table's PrettyCard), and a small [x]/[ ] toggle alongside the other actions for unix.

Closes #220

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
