### PR TITLE
docs: fix stale wiki content and document features missing since past…

### DIFF
--- a/docs/wiki/Background-Tasks.md
+++ b/docs/wiki/Background-Tasks.md
@@ -71,9 +71,9 @@ Only **one task runs at a time**, in the order it was queued. This avoids two ac
 | **Stop** | Running | Closes the underlying process. The task ends up in the **Stopped** state. |
 | **Remove** | Pending, Complete, Failed, or Stopped | Removes the task from the panel. A pending task removed this way never actually runs. |
 
-### Viewing live output
+### Viewing output
 
-Click anywhere on a **Running** or **Pending** task's row to reopen its log — the same streaming output view you'd see in the foreground modal, with a **Stop** button. Finished tasks don't reopen a log view; their outcome is already visible in the panel.
+Click anywhere on a task's row — **Pending**, **Running**, or already finished (**Complete**, **Failed**, **Stopped**) — to open its log. Output is captured from the moment the task starts, so finished tasks show the exact same output you'd have seen live, not just their final status. A **Running** task's log view includes a **Stop** button; a finished task's just has **Close**.
 
 ## Switching Docker/Podman while tasks are queued
 

--- a/docs/wiki/Bulk-Actions.md
+++ b/docs/wiki/Bulk-Actions.md
@@ -4,40 +4,38 @@ Select multiple stacks at once and run the same action (Up, Pull, Restart, Down,
 
 ## Selecting stacks
 
-Every [layout](Stacks-Dashboard#layout-options) has a small checkbox (or, in the Unix layout, a `[ ]` / `[x]` toggle) for selecting a stack. To keep the default view uncluttered, the checkbox is hidden until you either:
-
-- hover over (or focus) a stack row/card, or
-- have already selected at least one other stack — once one row is checked, all the checkboxes become visible.
+Every [layout](Stacks-Dashboard#layout-options) supports selecting a stack, but the control differs per layout:
 
 | Layout | Selection control |
 |---|---|
-| **Power User** | Checkbox at the start of the row |
-| **Minimal** | Checkbox in the top-left corner of the card |
-| **Pretty** | Checkbox in the top-left corner of the card |
-| **Unix** | `[ ]` / `[x]` bracket toggle alongside the other `[key]` actions |
+| **Power User** | A checkbox at the start of the row. To keep the default view uncluttered, it's hidden until you hover/focus the row, or until at least one stack is already selected (once one row is checked, all the checkboxes become visible). |
+| **Minimal** | Click anywhere on the card (except its buttons/menu) to toggle selection — the card gets a blue glow ring when selected. There is no checkbox. |
+| **Pretty** | Same as Minimal: click the card to toggle selection, shown with a blue glow ring. There is no checkbox. |
+| **Unix** | A `[ ]` / `[x]` bracket toggle alongside the other `[key]` actions. |
 
-Clicking a checkbox never triggers the row/card's own click-to-expand behavior.
+Clicking a checkbox, or clicking a card outside its action buttons, never triggers the row/card's own click-to-expand behavior.
 
 ## The bulk action bar
 
 Once at least one stack is selected, a bulk action bar appears in the dashboard toolbar:
 
 ```
-┌──────────────────────────────────────────────────────────┐
-│  2 selected   [Up]  (↻)  (⇩)  (⛔)   [Clear selection ✕] │
-└──────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│  ☑ 2 selected   [Up]  (↻)  (⇩)  (⛔)   [Clear selection ✕]        │
+└────────────────────────────────────────────────────────────────────┘
 ```
 
 | Control | Action |
 |---|---|
+| **☑ Select all** (checkbox, first in the bar) | Selects every stack currently displayed. Shows an indeterminate dash when some (but not all) stacks are selected. Toggling it off clears the selection but — unlike deselecting the last stack manually — **keeps the bar visible** with its action buttons grayed out, rather than hiding it immediately. |
 | **Up** (primary button, same color as the row-level Up button) | Bring all selected stacks up |
 | **↻ Restart** | Restart all selected stacks |
 | **⇩ Pull** | Pull the latest images for all selected stacks |
 | **⛔ Down** (red) | Stop and remove all selected stacks |
 | **⛔ Kill** (red) | Force-kill all selected stacks |
-| **✕ Clear selection** | Deselect everything without running an action |
+| **✕ Clear selection** | Deselect everything and immediately dismiss the bar |
 
-Each icon button shows the same tooltip text as its single-stack counterpart on the stack row.
+Each icon button shows the same tooltip text as its single-stack counterpart on the stack row. Whenever the selection drops to zero — whether by toggling Select all off or by manually unchecking the last stack — the action buttons gray out but the bar itself stays put for a few seconds before auto-hiding, so you don't lose your place if you're about to select something else. Clicking **✕ Clear selection** always dismisses the bar immediately, regardless of that timer.
 
 ## Confirmation modal
 

--- a/docs/wiki/Importing-Stacks.md
+++ b/docs/wiki/Importing-Stacks.md
@@ -5,17 +5,19 @@ The **Stopped / offline stacks** section at the bottom of the dashboard shows co
 ## The Stopped section
 
 ```
-┌────────────────────────────────────────────────────────────┐
-│  Stopped / offline stacks                                  │
-│  [Create]  [▼ Import]                                      │
+┌──────────────────────────────────────────────────────────────┐
+│  Stopped / offline stacks                                    │
+│  [Create]  [▼ Import]  [Restore]           [Prune images]    │
 ├────────────────────────────────────────────────────────────┤
-│  myapp   ● down   /etc/docker/compose/myapp/compose.yml    │
-│                              [↑ Up]  [Edit]  [✕ Delete]    │
+│  myapp   ● down   /etc/docker/compose/myapp/compose.yml      │
+│                    [↑ Up]  [Edit]  [Backup]  [✕ Delete]      │
 ├────────────────────────────────────────────────────────────┤
-│  oldsite  ● down  /etc/docker/compose/oldsite/compose.yml  │
-│                              [↑ Up]  [Edit]  [✕ Delete]    │
-└────────────────────────────────────────────────────────────┘
+│  oldsite  ● down  /etc/docker/compose/oldsite/compose.yml    │
+│                    [↑ Up]  [Edit]  [Backup]  [✕ Delete]      │
+└──────────────────────────────────────────────────────────────┘
 ```
+
+The toolbar above the list also has **Restore** (see [Backup and Restore](Backup-and-Restore)) and, pinned to the right edge, **Prune images** — a host-wide unused-image cleanup that isn't limited to these stacks (see [Global image prune](Prune-Resources#global-image-prune-all-stacks)).
 
 Each row shows:
 
@@ -26,6 +28,7 @@ Each row shows:
 | **File path** | Full path to the `docker-compose.yml` (or `compose.yml`) file |
 | **Up** | Bring the stack online — see [Managing Stacks](Managing-Stacks) |
 | **Edit** | Open the YAML editor — see [Editing Configuration](Editing-Configuration) |
+| **Backup** | Archive the stack's files — see [Backup and Restore](Backup-and-Restore) |
 | **Delete** | Delete the compose file from disk (two-step confirmation) |
 
 ## Scanning for compose files
@@ -123,3 +126,18 @@ Click **Delete** to proceed to the second confirmation.
 Click **Yes, delete** to confirm. The file (or folder) is deleted and the stack disappears from the list.
 
 > **Note:** Delete only removes files from disk. It does not stop running containers. If you want to stop containers first, use **Down** from the running stacks section before deleting.
+
+## Selecting multiple downed stacks and bulk Up
+
+The downed stacks list supports the same kind of multi-select as the running-stacks dashboard (see [Bulk Actions](Bulk-Actions)), with the selection control adapted per [layout](Stacks-Dashboard#layout-options):
+
+| Layout | Selection control |
+|---|---|
+| **Power User** | A checkbox at the start of the row, hidden until you hover/focus a row or already have something selected. |
+| **Minimal** | Same checkbox behavior, shown next to the stack name on the card. |
+| **Pretty** | Click anywhere on the card (except its buttons) to toggle selection — it glows blue when selected, exactly like the running-stacks Pretty layout. |
+| **Unix** | A small `[ ]` / `[x]` toggle at the start of the action row. |
+
+Once at least one stack is selected, a bulk bar appears with a **select all** toggle and a single **Up** action (down stacks only support being brought back up in bulk — there's no bulk Restart/Pull/Down/Kill here). Like the main dashboard's bulk bar, toggling select-all off — or deselecting everything manually — keeps the bar visible with **Up** grayed out instead of hiding it immediately; the explicit **✕** clear button dismisses it right away.
+
+Confirming **Up** enqueues one background task per selected stack (see [Background Tasks](Background-Tasks)); each stack disappears from this list as its task completes successfully.

--- a/docs/wiki/Prune-Resources.md
+++ b/docs/wiki/Prune-Resources.md
@@ -1,6 +1,8 @@
 # Prune Resources
 
-The Prune modal removes unused Docker resources associated with a stack — old image versions, stopped containers, unused volumes, and orphaned networks. This frees up disk space and keeps your Docker environment tidy.
+There are two ways to reclaim disk space: pruning resources for **one stack** (this page's main flow, below), or the **global image prune** covering every image on the host regardless of which stack it belongs to (see [Global image prune](#global-image-prune-all-stacks) further down).
+
+The per-stack Prune modal removes unused Docker resources associated with a stack — old image versions, stopped containers, unused volumes, and orphaned networks. This frees up disk space and keeps your Docker environment tidy.
 
 > **Warning:** Pruning volumes deletes their data permanently. There is no undo. Make sure you have backups before pruning volumes.
 
@@ -47,7 +49,7 @@ This warning exists because Docker cannot determine which volumes are "in use" w
 
 | Resource | What gets removed |
 |---|---|
-| **Images** | Older versions of images used by this stack that are no longer referenced by any container. The currently-used image version is kept. |
+| **Images** | Older *named* versions of images used by this stack that are no longer referenced by any container. The currently-used image version is kept. This only catches images that still have a tag matching this stack's repos — it won't find images that lost their tag entirely (e.g. after re-pulling a floating tag like `:latest`), or images belonging to a stack that's fully down (no container exists to identify which repos to check). Use [Global image prune](#global-image-prune-all-stacks) for those. |
 | **Containers** | Stopped containers that belong to this stack (identified by Compose project labels). Running containers are never removed. |
 | **Volumes** | Named volumes defined in the compose file that are not currently mounted by any running container. **Data inside these volumes is permanently deleted.** |
 | **Networks** | Custom networks created by the compose file that are not currently in use by any running container. In-use networks are automatically skipped. |
@@ -86,3 +88,44 @@ Review the list carefully. If you see something you did not intend to remove, cl
 Click **Prune selected** (danger button) to delete the listed resources. The operation runs and the modal closes when complete.
 
 To go back without pruning, click **← Back** or **Cancel**.
+
+## Global image prune (all stacks)
+
+The per-stack flow above can miss unused images in two common cases: a floating tag like `:latest` gets re-pulled and the old image loses its tag entirely (it becomes "dangling"), or a stack is fully down and so has no container left to tell the app which of its images are still relevant. **Global image prune** covers both, by scanning every image on the host and comparing against every container's actual image ID (not by name) — not just this one stack's.
+
+### Opening it
+
+The **Prune images** button sits at the right edge of the same toolbar row as **Create**, **Import**, and **Restore**, above the [downed stacks list](Importing-Stacks) (icon-only in Minimal/Unix layouts).
+
+### Preview and confirm
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Prune unused images                               [✕]   │
+├──────────────────────────────────────────────────────────┤
+│  ℹ This scans for images not currently used by any        │
+│    container, across the whole host — not just one       │
+│    stack...                                               │
+│                                                            │
+│  ID                   Repository:Tag        Size   Created│
+│  a1b2c3d4e5f6         myapp:latest          128MB  2 days │
+│  f6e5d4c3b2a1         <none>:<none>         64MB   3 weeks│
+│                                                            │
+│  Total reclaimable: 192MiB                                │
+│                                                            │
+│  ⚠ This will permanently delete these images              │
+│    2 image(s) will be removed. If any belong to a         │
+│    currently down stack, that stack will need to re-pull  │
+│    them the next time it's brought up. This cannot be     │
+│    undone.                                                │
+│                                                            │
+│  [ ] I understand this will permanently delete the        │
+│      images listed above                                  │
+├──────────────────────────────────────────────────────────┤
+│                          [Prune]  [Cancel]                │
+└──────────────────────────────────────────────────────────┘
+```
+
+The **Prune** button stays disabled until you tick the confirmation checkbox. Confirming runs the native `docker image prune -a` / `podman image prune -a` under the hood — the same well-tested command you'd run manually — and shows its own reported output (e.g. the total space reclaimed) once done.
+
+> **Note:** This is host-wide, not scoped to a single stack. If an image belongs to a currently-down stack, that stack will need to re-pull it the next time it's brought up.


### PR DESCRIPTION
… releases

Bulk-Actions.md still described Minimal/Pretty layouts as using a checkbox for selection; #210 replaced that with click-to-select-glow a few releases ago and the wiki was never updated. Also documents the select-all toggle added in #216 (grays out the bar instead of hiding it when the selection empties).

Background-Tasks.md claimed finished tasks can't reopen their log — no longer true after #217.

Prune-Resources.md and Importing-Stacks.md had no mention of the new global "Prune images" action (#218) or the downed-stacks select-all and bulk Up feature (#220); Importing-Stacks.md was also missing the Restore and per-row Backup buttons, which predate this session but were never documented.

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
