### PR TITLE
fix: escalate to superuser when saving edits to existing compose files

### DIFF
--- a/src/components/YamlModal.tsx
+++ b/src/components/YamlModal.tsx
@@ -256,8 +256,9 @@ export function YamlModal({ stack, onClose, onFileAdded, onFileRemoved }: Props)
     setError(null);
     setConfirmSave(false);
     try {
-      await saveSnapshot(configFile, content);
-      await saveComposeFile(configFile, editedContent);
+      const su = await composeFileSuperuser([configFile]);
+      await saveSnapshot(configFile, content, su);
+      await saveComposeFile(configFile, editedContent, su);
       setContent(editedContent);
       setEditing(false);
       await loadSnapshots();


### PR DESCRIPTION
performSave() in YamlModal never computed the superuser flag before writing, unlike every other mutating call site in the app. This broke saving edits to compose files owned by another user/root (e.g. stacks created by Dockge), failing with "Not permitted to perform this action" even though creating a brand-new file worked fine.

Fixes #234

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [x] Manually tested in Cockpit (if UI change)
