### PR TITLE
fix: package the assets directory (fonts, pficon icons) in deb/rpm bu…

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -18,4 +18,5 @@ package() {
     install -m 0644 "${pkgname}/manifest.json" "${pkgdir}/usr/share/cockpit/${pkgname}/"
     install -m 0644 "${pkgname}/index.html"    "${pkgdir}/usr/share/cockpit/${pkgname}/"
     install -m 0644 "${pkgname}/README.md"     "${pkgdir}/usr/share/cockpit/${pkgname}/"
+    cp -r "${pkgname}/assets"                  "${pkgdir}/usr/share/cockpit/${pkgname}/"
 }

--- a/cockpit-compose.spec
+++ b/cockpit-compose.spec
@@ -25,6 +25,7 @@ install -m 0644 main.js       %{buildroot}%{_datadir}/cockpit/cockpit-compose/
 install -m 0644 main.css      %{buildroot}%{_datadir}/cockpit/cockpit-compose/
 install -m 0644 manifest.json %{buildroot}%{_datadir}/cockpit/cockpit-compose/
 install -m 0644 index.html    %{buildroot}%{_datadir}/cockpit/cockpit-compose/
+cp -r assets                  %{buildroot}%{_datadir}/cockpit/cockpit-compose/
 
 %files
 %doc README.md

--- a/debian/install
+++ b/debian/install
@@ -2,3 +2,4 @@ cockpit-compose/main.js       usr/share/cockpit/cockpit-compose/
 cockpit-compose/main.css      usr/share/cockpit/cockpit-compose/
 cockpit-compose/manifest.json usr/share/cockpit/cockpit-compose/
 cockpit-compose/index.html    usr/share/cockpit/cockpit-compose/
+cockpit-compose/assets        usr/share/cockpit/cockpit-compose/


### PR DESCRIPTION
…ilds

main.css references assets/fonts/*.woff2 and assets/pficon/*, but debian/install and the RPM spec only installed main.js, main.css, manifest.json, and index.html — the assets directory was never shipped, so every font and icon 404'd once installed from a package.

Fixes #235

## Description

What does this change do? (Briefly describe the what and why.)

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Chore / Refactor

## Testing

- [x] CI passes (lint, typecheck, tests, build)
- [x] Tests added or updated (if applicable)
- [ ] Manually tested in Cockpit (if UI change)
