### PR TITLE
build(deps-dev): bump react and react-dom to 19.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,8 @@
         "esbuild": "^0.28.1",
         "eslint": "^9.39.4",
         "jsdom": "^29.1.1",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10"
       },
@@ -5758,25 +5758,25 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-dropzone": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "esbuild": "^0.28.1",
     "eslint": "^9.39.4",
     "jsdom": "^29.1.1",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },


### PR DESCRIPTION
## Summary
- Bumps react and react-dom together from 19.2.7 to 19.2.8.
- Dependabot opened these as two separate PRs (#244, #243). Merging either alone leaves a react/react-dom version mismatch that crashes every component test (react-dom-client.development.js throws during render). Bundling the bump here avoids that.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npx vitest run` (1445 tests passing)