### PR TITLE
fix: use import attributes syntax instead of deprecated assertions

### DIFF
--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -4,8 +4,7 @@ import { PageSection, Label } from "@patternfly/react-core";
 import { Tooltip } from "@rxtx4816/cockpit-plugin-base-react/components";
 import { HelpPopover } from "./HelpPopover";
 import { composeVersion, containerVersion, isRootlessMode, getDockerSocketPath, getPodmanSocketPath, SOCKET_MODE_CHANGE_EVENT, type ComposeVersion, type Runtime } from "../api";
-// @ts-expect-error: ESM import assertion for JSON
-import pkg from "../../package.json" assert { type: "json" };
+import pkg from "../../package.json" with { type: "json" };
 
 interface Props {
   runtime: Runtime;


### PR DESCRIPTION
## Summary
- Switches AppFooter's JSON import from the deprecated \`assert { type: 'json' }\` to \`with { type: 'json' }\`.
- Prep work for #229 (TypeScript 7): TS7 removes the old assertion syntax (TS2880). Works fine on current TS 6.0.3 too, so this is safe to land now — no @ts-expect-error needed anymore either.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npx vitest run src/components/AppFooter.test.tsx\`