### PR TITLE
fix: avoid Go template index() crash on podman ps Labels for network listing

### DIFF
--- a/src/api/stacks/query.test.ts
+++ b/src/api/stacks/query.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from "vitest";
-import { groupPodmanContainers } from "./query";
+import { describe, it, expect, beforeEach } from "vitest";
+import { mockSpawn } from "../../test/setup";
+import { mockProcess } from "../../test/helpers";
+import { setRuntime } from "../cockpit";
+import { groupPodmanContainers, listNetworkConnectedProjects } from "./query";
+
+beforeEach(() => {
+  mockSpawn.mockReset();
+  mockSpawn.mockReturnValue(mockProcess(""));
+  setRuntime("docker");
+});
 
 describe("groupPodmanContainers", () => {
   it("groups single-container project", () => {
@@ -130,5 +139,33 @@ describe("groupPodmanContainers", () => {
       },
     ]);
     expect(result[0].ConfigFiles).toBe("/home/test/testcompose/myapp/docker-compose.yml");
+  });
+});
+
+// Regression for #259: `ps --format {{index .Labels "..."}}` errors on Podman
+// 6.0.1 ("cannot index slice/array with type string"), which broke Stack
+// Info's entire Networks section. Go through --format json + JS parsing for
+// the podman branch instead, matching every other podman fallback in this file.
+describe("listNetworkConnectedProjects", () => {
+  it("docker mode: uses the --format .Label syntax", () => {
+    listNetworkConnectedProjects("mynet");
+    const args = mockSpawn.mock.calls[0][0] as string[];
+    expect(args.join(" ")).toContain("network=mynet");
+    expect(args.join(" ")).toContain(".Label");
+  });
+
+  it("podman mode: uses --format json (not the Go template) and parses labels in JS", async () => {
+    setRuntime("podman");
+    mockSpawn.mockReturnValue(mockProcess(JSON.stringify([
+      { Labels: { "com.docker.compose.project": "myapp" } },
+      { Labels: { "com.docker.compose.project": "otherapp" } },
+      { Labels: {} },
+    ])));
+    const out = await listNetworkConnectedProjects("mynet");
+    expect(out).toBe("myapp\notherapp");
+    const args = mockSpawn.mock.calls[0][0] as string[];
+    expect(args.join(" ")).toContain("network=mynet");
+    expect(args).toContain("json");
+    expect(args.join(" ")).not.toContain("index .Labels");
   });
 });

--- a/src/api/stacks/query.ts
+++ b/src/api/stacks/query.ts
@@ -298,12 +298,34 @@ export function listProjectNetworks(project: string): CockpitProcess {
   );
 }
 
+// Podman's `ps --format {{index .Labels "..."}}` Go template errors on at
+// least Podman 6.0.1 ("cannot index slice/array with type string") — its ps
+// JSON's Labels field doesn't round-trip through text/template indexing the
+// way Docker's does. Go through --format json and read the label in JS
+// instead, avoiding the template entirely (same approach already used for
+// every other podman-specific fallback in this file).
+function listNetworkConnectedProjectsPodman(networkName: string): CockpitProcess {
+  return makeFakeProcess(async () => {
+    let raw = "";
+    const proc = cockpit.spawn(
+      cli("ps", "--filter", `network=${networkName}`, "--format", "json"),
+      { superuser: socketSuperuser(), err: "message", ...dockerSpawnEnviron() },
+    );
+    proc.stream(d => { raw += d; });
+    await proc;
+    interface PsEntry { Labels?: Record<string, string> }
+    const containers = JSON.parse(raw) as PsEntry[];
+    return containers
+      .map(c => c.Labels?.["com.docker.compose.project"] ?? "")
+      .filter(Boolean)
+      .join("\n");
+  });
+}
+
 export function listNetworkConnectedProjects(networkName: string): CockpitProcess {
-  const labelTpl = getIsPodman()
-    ? `{{index .Labels "com.docker.compose.project"}}`
-    : `{{.Label "com.docker.compose.project"}}`;
+  if (getIsPodman()) return listNetworkConnectedProjectsPodman(networkName);
   return cockpit.spawn(
-    cli("ps", "--filter", `network=${networkName}`, "--format", labelTpl),
+    cli("ps", "--filter", `network=${networkName}`, "--format", `{{.Label "com.docker.compose.project"}}`),
     { superuser: socketSuperuser(), err: "message", ...dockerSpawnEnviron() },
   );
 }


### PR DESCRIPTION
## Summary
- `listNetworkConnectedProjects` used a `podman ps --format {{index .Labels "..."}}` Go template that errors on Podman 6.0.1 ("cannot index slice/array with type string"), breaking Stack Info's Networks section with a generic "Could not load networks" alert.
- Switches the podman branch to `--format json` + JS-side label parsing, matching every other podman fallback already in this file.

Fixes #259

## Test plan
- [x] `src/api/stacks/query.test.ts` regression test asserting the podman branch uses `--format json` and never emits the Go template
- [x] `e2e/stack-info.spec.ts` — verified live against `arch-podman` (Podman 6.0.1): Networks section now shows the real network name instead of the error alert