### PR TITLE
docs: correct port-click behavior — no confirmation modal exists

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1062,10 +1062,9 @@ two or three times to accumulate more stopped containers.
 
 **Steps:**
 1. In the stack row, the port `8080` is shown as a clickable link.
-2. Click the port → external link modal warns about leaving the page → click Continue.
-3. Browser opens `http://localhost:8080`.
-4. **Localhost-only port** (e.g. `127.0.0.1:8080:80`): link has a lock/localhost tooltip.
-5. **All-interfaces port** (e.g. `0.0.0.0:8080:80`): link has a globe/external tooltip.
+2. Click the port → browser opens `http://localhost:8080` directly in a new tab, no confirmation prompt.
+3. **Localhost-only port** (e.g. `127.0.0.1:8080:80`): link has a lock/localhost tooltip.
+4. **All-interfaces port** (e.g. `0.0.0.0:8080:80`): link has a globe/external tooltip.
 
 ---
 

--- a/docs/wiki/Stacks-Dashboard.md
+++ b/docs/wiki/Stacks-Dashboard.md
@@ -57,7 +57,7 @@ Each stack appears as a collapsible row. The row shows a summary when collapsed 
 | **Status label** | Running, Partial, Stopped, Paused, or Unknown |
 | **Health badge** | ✓ Healthy, ⚠ Partial, or Unhealthy — reflects the aggregate health of all services |
 | **Service count** | Number of services defined in the compose file |
-| **Ports** | Exposed ports shown as blue `host:container` badges. Ports that resolve to a reachable URL are clickable — clicking opens an external-link confirmation and then opens the service in a new browser tab. Localhost-bound ports are only clickable when Cockpit itself runs on localhost. |
+| **Ports** | Exposed ports shown as blue `host:container` badges. Ports that resolve to a reachable URL are clickable — clicking opens the service directly in a new browser tab (no confirmation prompt). Localhost-bound ports are only clickable when Cockpit itself runs on localhost. |
 | **CPU %** | Real-time CPU usage across all containers in the stack |
 | **Memory** | Real-time memory usage across all containers in the stack |
 


### PR DESCRIPTION
## Summary
- `docs/wiki/Stacks-Dashboard.md` and `docs/testing.md` §6.22 described clicking a port badge as going through an "external-link confirmation" modal.
- The real code (`StatsCell.tsx`/`PrettyCard.tsx`/`UnixRow.tsx`) calls `window.open()` directly with no confirmation step in between.
- Docs-only change per product decision — behavior stays as-is.

Fixes #260

## Test plan
- [x] `e2e/ports.spec.ts` asserts the real (no-confirmation) behavior