### PR TITLE
fix: warn on duplicate env keys added in Raw mode, not just Table mode

### DIFF
--- a/e2e/env-editor.spec.ts
+++ b/e2e/env-editor.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
+import type { Locator, Page } from '@playwright/test';
+import { baseData } from './helpers/base';
+import { openYamlEditor } from './helpers/stacks';
+
+// `env-test` (nginx + a real .env with APP_ENV/SECRET_KEY/DEBUG — see
+// scripts/test-vm.config.sh) is a downed fixture, so no lifecycle bring-up is
+// needed; the editor reads/writes real files on disk regardless of stack state.
+//
+// EnvTable renders each row's key/value as controlled <input>s (PatternFly
+// TextInput) — React sets these via the DOM `value` *property*, not the HTML
+// `value` *attribute*, so a `input[value="..."]` CSS attribute selector is
+// unreliable (only ever matches an input's very first render, never a value
+// set by a later re-render). `rowByKey` instead reads each row's live
+// `.inputValue()` to find the right one.
+async function rowByKey(modal: Locator, key: string): Promise<Locator> {
+  const rows = modal.locator('tr.env-row-entry');
+  const count = await rows.count();
+  for (let i = 0; i < count; i++) {
+    const row = rows.nth(i);
+    if (await row.getByLabel('Variable key').inputValue() === key) return row;
+  }
+  throw new Error(`No env row found with key "${key}"`);
+}
+
+function envModal(page: Page) {
+  return page.getByRole('dialog', { name: /Env file — env-test/ });
+}
+
+// Opens the compose YAML editor (parent) once, then the nested Env file modal
+// on top of it — reopening via Cancel/Save leaves the parent YamlModal open
+// underneath the whole time, so subsequent re-opens only need the "Env file"
+// button, not a fresh openYamlEditor() (which would try to click the downed
+// card's "Edit compose file" button while it's obscured by the still-open
+// YamlModal, and hang).
+async function openEnvModal(page: Page): Promise<Locator> {
+  await page.getByRole('button', { name: 'Env file' }).click();
+  const modal = envModal(page);
+  await expect(modal).toBeVisible();
+  // Each open re-fetches the file from disk (findEnvFiles + readEnvFile) and
+  // shows a spinner until it resolves — wait for at least one real row
+  // before querying rows, otherwise rowByKey can run against an empty table.
+  await expect(modal.locator('tr.env-row-entry').first()).toBeVisible({ timeout: 10000 });
+  return modal;
+}
+
+test('Env file editor reads real values, edits and saves them, and the change persists to disk', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+  await openYamlEditor(page, 'env-test');
+  const modal = await openEnvModal(page);
+
+  // Real content from disk, not a blank form.
+  const appEnvRow = await rowByKey(modal, 'APP_ENV');
+  await expect(appEnvRow.getByLabel('Variable value')).toHaveValue('development');
+
+  // Edit the DEBUG value and save.
+  const debugRow = await rowByKey(modal, 'DEBUG');
+  await debugRow.getByLabel('Variable value').fill('false');
+  await modal.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(modal).not.toBeVisible({ timeout: 10000 });
+
+  // Real effect: reopen and confirm the saved value actually persisted to disk.
+  const reopened = await openEnvModal(page);
+  const reopenedDebugRow = await rowByKey(reopened, 'DEBUG');
+  await expect(reopenedDebugRow.getByLabel('Variable value')).toHaveValue('false', { timeout: 10000 });
+
+  // Restore the original value so repeat runs of this spec stay idempotent.
+  await reopenedDebugRow.getByLabel('Variable value').fill('true');
+  await reopened.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(reopened).not.toBeVisible({ timeout: 10000 });
+});
+
+test('Env file editor warns on a duplicate key added via Table mode instead of silently saving it', async ({ pluginPage: page }) => {
+  test.setTimeout(90_000);
+  await baseData(page);
+  await openYamlEditor(page, 'env-test');
+  const modal = await openEnvModal(page);
+  await expect(await rowByKey(modal, 'APP_ENV')).toBeVisible({ timeout: 10000 });
+
+  await modal.getByRole('button', { name: 'Add variable' }).click();
+  const newRow = modal.locator('tr.env-row-entry').last();
+  await newRow.getByLabel('Variable key').fill('APP_ENV');
+  await newRow.getByLabel('Variable value').fill('staging');
+
+  await modal.getByRole('button', { name: 'Save', exact: true }).click();
+  const confirm = page.getByRole('dialog', { name: 'Confirm save' });
+  await expect(confirm).toBeVisible();
+  await expect(confirm.getByText(/Duplicate keys found/i)).toBeVisible();
+
+  // Cancel the warning — the file must be left untouched on disk.
+  await confirm.getByRole('button', { name: 'Cancel' }).click({ timeout: 20000 });
+  await expect(confirm).not.toBeVisible({ timeout: 10000 });
+  // Not scoped through the `modal` (role=dialog) locator here: PatternFly
+  // appears to leave the EnvModal's dialog subtree marked aria-hidden for a
+  // beat after the nested confirm dialog closes (likely inert/focus-trap
+  // bookkeeping for the outgoing nested modal), which makes any role-based
+  // query against it resolve to zero elements even though it's visibly
+  // present and clickable — a real, if minor, a11y bug worth a follow-up
+  // issue. Querying by plain text at the page level sidesteps it.
+  await page.getByText('Cancel', { exact: true }).last().click({ timeout: 20000 });
+  await expect(modal).not.toBeVisible();
+
+  const reopened = await openEnvModal(page);
+  const reopenedAppEnvRow = await rowByKey(reopened, 'APP_ENV');
+  await expect(reopenedAppEnvRow.getByLabel('Variable value')).toHaveValue('development', { timeout: 10000 });
+  await expect(reopened.locator('tr.env-row-entry')).toHaveCount(3);
+  await reopened.getByRole('button', { name: 'Cancel', exact: true }).click();
+});
+
+// Regression for #261: a duplicate key added purely in Raw mode used to save
+// silently with no warning — EnvModal only computed `hasDuplicates` via
+// EnvTable's onDuplicatesChange callback, which never ran while the Raw
+// (CodeMirror) editor was mounted instead of the Table view. Fixed in
+// src/components/EnvModal.tsx to also re-check the actual saved content
+// directly (src/lib/envDuplicates.ts hasDuplicateEnvKeys), independent of
+// which view mode produced it.
+test('Env file editor warns on a duplicate key added via Raw mode too, not just Table mode', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+  await openYamlEditor(page, 'env-test');
+  const modal = await openEnvModal(page);
+  await expect(await rowByKey(modal, 'APP_ENV')).toBeVisible({ timeout: 10000 });
+
+  await modal.getByRole('button', { name: 'Raw', exact: true }).click();
+  const raw = modal.locator('.cm-content');
+  await expect(raw).toBeVisible({ timeout: 10000 });
+  await raw.click();
+  await page.keyboard.press('Control+A');
+  await page.keyboard.type('APP_ENV=development\nSECRET_KEY=test-secret-123\nDEBUG=true\nAPP_ENV=staging\n');
+
+  await modal.getByRole('button', { name: 'Save', exact: true }).click();
+  const confirm = page.getByRole('dialog', { name: 'Confirm save' });
+  await expect(confirm).toBeVisible();
+  await expect(confirm.getByText(/Duplicate keys found/i)).toBeVisible();
+
+  // Cancel the warning — the file must be left untouched on disk.
+  await confirm.getByRole('button', { name: 'Cancel' }).click({ force: true, timeout: 30000 });
+  await expect(confirm).not.toBeVisible({ timeout: 10000 });
+  await page.getByText('Cancel', { exact: true }).last().click({ force: true, timeout: 30000 });
+  await expect(modal).not.toBeVisible();
+
+  const reopened = await openEnvModal(page);
+  const reopenedAppEnvRow = await rowByKey(reopened, 'APP_ENV');
+  await expect(reopenedAppEnvRow.getByLabel('Variable value')).toHaveValue('development', { timeout: 10000 });
+  await expect(reopened.locator('tr.env-row-entry')).toHaveCount(3);
+  await reopened.getByRole('button', { name: 'Cancel', exact: true }).click();
+});

--- a/src/components/EnvModal.test.tsx
+++ b/src/components/EnvModal.test.tsx
@@ -212,18 +212,38 @@ describe("EnvModal", () => {
     expect(screen.queryByTestId("env-editor")).toBeNull();
   });
 
-  it("saves raw editor content directly without duplicate check", async () => {
+  // Regression for #261: a duplicate key introduced purely in Raw mode used to
+  // save silently, since EnvTable's onDuplicatesChange (the only thing that
+  // set hasDuplicates) never ran while Raw mode was active. handleSave now
+  // also re-checks the actual saved content directly, independent of viewMode.
+  it("warns on duplicate keys introduced in raw mode, same as table mode", async () => {
     mockRead.mockResolvedValue("FOO=bar\n");
     const onClose = vi.fn();
     render(<EnvModal stack={stack} onClose={onClose} />);
     await waitFor(() => screen.getByTestId("env-editor"));
-    // Switch to raw mode first
     fireEvent.click(screen.getByRole("button", { name: /^Raw$/i }));
     await waitFor(() => screen.getByTestId("env-editor-raw"));
     fireEvent.change(screen.getByTestId("env-editor-raw"), { target: { value: "FOO=a\nFOO=b\n" } });
     fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
-    // Should save immediately without confirm dialog even though keys would be duplicate
+    await waitFor(() => expect(screen.getByText(/Duplicate keys found/i)).toBeInTheDocument());
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Save Anyway/i }));
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("FOO=a\nFOO=b\n"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("saves raw editor content directly when there are no duplicate keys", async () => {
+    mockRead.mockResolvedValue("FOO=bar\n");
+    const onClose = vi.fn();
+    render(<EnvModal stack={stack} onClose={onClose} />);
+    await waitFor(() => screen.getByTestId("env-editor"));
+    fireEvent.click(screen.getByRole("button", { name: /^Raw$/i }));
+    await waitFor(() => screen.getByTestId("env-editor-raw"));
+    fireEvent.change(screen.getByTestId("env-editor-raw"), { target: { value: "FOO=a\nBAR=b\n" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("FOO=a\nBAR=b\n"));
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/src/components/EnvModal.tsx
+++ b/src/components/EnvModal.tsx
@@ -21,6 +21,7 @@ import { EnvEditor } from "./EnvEditor";
 import "./YamlModal.css";
 import "./EnvModal.css";
 import { splitConfigFiles } from "../lib/configFiles";
+import { hasDuplicateEnvKeys } from "../lib/envDuplicates";
 
 interface Props {
   stack: ComposeStack;
@@ -121,7 +122,13 @@ export function EnvModal({ stack, onClose }: Props) {
   };
 
   const handleSave = async () => {
-    if (viewMode === "table" && hasDuplicates) {
+    // Table mode already tracks this live via EnvTable's onDuplicatesChange,
+    // but that callback never runs while Raw mode is active — re-check every
+    // file's actual content directly here so a duplicate introduced purely in
+    // Raw mode still gets caught (issue #261), not just ones caught while
+    // Table mode happened to be mounted.
+    const anyDuplicates = hasDuplicates || Object.values(fileCache).some(f => hasDuplicateEnvKeys(f.content));
+    if (anyDuplicates) {
       setConfirmSave(true);
       return;
     }

--- a/src/lib/envDuplicates.test.ts
+++ b/src/lib/envDuplicates.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { hasDuplicateEnvKeys } from "./envDuplicates";
+
+describe("hasDuplicateEnvKeys", () => {
+  it("returns false for unique keys", () => {
+    expect(hasDuplicateEnvKeys("FOO=a\nBAR=b\n")).toBe(false);
+  });
+
+  it("returns true for a repeated key", () => {
+    expect(hasDuplicateEnvKeys("FOO=a\nFOO=b\n")).toBe(true);
+  });
+
+  it("ignores comment lines", () => {
+    expect(hasDuplicateEnvKeys("# FOO=a\nFOO=b\n")).toBe(false);
+  });
+
+  it("ignores blank lines", () => {
+    expect(hasDuplicateEnvKeys("FOO=a\n\nBAR=b\n")).toBe(false);
+  });
+
+  it("ignores lines without an =", () => {
+    expect(hasDuplicateEnvKeys("not a real line\nFOO=a\n")).toBe(false);
+  });
+
+  it("returns false for empty content", () => {
+    expect(hasDuplicateEnvKeys("")).toBe(false);
+  });
+
+  it("only counts the part before the first = as the key", () => {
+    expect(hasDuplicateEnvKeys("FOO=a=b\nFOO=c\n")).toBe(true);
+  });
+});

--- a/src/lib/envDuplicates.ts
+++ b/src/lib/envDuplicates.ts
@@ -1,0 +1,15 @@
+// Mirrors the key-extraction rules in the base library's EnvTable
+// (@rxtx4816/cockpit-plugin-base-react/components) parseContent/hasDuplicateKeys:
+// comment lines (start with #) and lines without an "=" are ignored, everything
+// before the first "=" on a real line is the key. Kept here so EnvModal can run
+// the same duplicate check on raw .env text directly, independent of which view
+// mode (Table vs Raw) produced it — EnvTable's own duplicate detection only runs
+// while it's mounted, so a duplicate introduced purely in Raw mode was silently
+// saved with no warning (issue #261).
+export function hasDuplicateEnvKeys(content: string): boolean {
+  const keys = content
+    .split("\n")
+    .filter(line => line.trim() !== "" && !line.startsWith("#") && line.includes("="))
+    .map(line => line.substring(0, line.indexOf("=")));
+  return keys.length !== new Set(keys).size;
+}


### PR DESCRIPTION
## Summary
- `EnvModal.tsx` only computed `hasDuplicates` via `EnvTable`'s `onDuplicatesChange`, which never fires while the Raw (CodeMirror) editor is mounted — a duplicate key introduced entirely in Raw mode silently saved with no warning, despite `docs/testing.md` §6.15 documenting the warning as mode-agnostic.
- Adds `src/lib/envDuplicates.ts` (`hasDuplicateEnvKeys`) and wires it into `handleSave()` so Raw-mode content is checked the same way Table mode already is.

Fixes #261

## Test plan
- [x] `src/lib/envDuplicates.test.ts` — 7 unit tests
- [x] `src/components/EnvModal.test.tsx` — updated to cover the warn-on-raw-mode-duplicates path and the no-duplicates save path