### PR TITLE
test: finish remaining Wave 2 items + fix a real hardcoded-VM test bug

### DIFF
--- a/docs/wiki/E2E-Test-Inventory.md
+++ b/docs/wiki/E2E-Test-Inventory.md
@@ -46,13 +46,13 @@ Run these against the full matrix (batched per §"Managing resource usage" in
 |---|---|---|---|
 | 6.20, 6.21 | Footer + runtime toggle (Docker↔Podman switch, rootless badge, socket path, "not installed" revert) | `e2e/runtime-toggle.spec.ts` | ✅ (`arch-both`; "not installed" case breaks the real `podman` binary via SSH, always restored) |
 | 7.1 | Docker rootless mode | `e2e/runtime-rootless.spec.ts` | ✅ partial (`rootless-compose-root.spec.ts`) / 🚧 |
-| 7.2 | Podman via `podman compose` external provider | `e2e/runtime-rootless.spec.ts` | 🚧 |
-| 7.3 | Podman via `podman-compose` (Python, no docker-compose) | `e2e/runtime-rootless.spec.ts` | 🚧 |
+| 7.2 | Podman via `podman compose` external provider | (every spec that runs against `arch-podman`) | ✅ — on `arch-podman`, `podman compose`'s "external compose provider" genuinely *is* `/usr/bin/podman-compose` (verified via SSH: `podman compose version` prints the "Executing external compose provider" banner naming that exact binary); every Wave 1/3/4 spec already run against this VM exercises this path, no dedicated spec needed |
+| 7.3 | Podman via `podman-compose` (Python, no docker-compose) | (every spec that runs against `arch-podman`) | ✅ — same finding as 7.2: `arch-podman` has no `docker-compose` at all and its `podman-compose` is confirmed genuine Python (`/usr/bin/podman-compose` is `#!/usr/bin/python`, reports `podman-compose version 1.6.0`), so 7.2 and 7.3 are literally the same code path on this VM, both already covered by the existing suite |
 | 7.4 | Podman root (system socket), no rootless socket at all — issue [#242](https://github.com/RXTX4816/cockpit-compose/issues/242) regression: discovery + Stack Info container list under real Cockpit Administrative access | `e2e/runtime-rootless.spec.ts` (`fedora-podman-rootful` only) | ✅ |
-| 7.5 | Neither runtime present — error state | `e2e/runtime-unavailable.spec.ts` | 🚧 |
-| Rootless/Rootful socket-mode toggle (added alongside #242's fix) — switching modes when both sockets are detected, footer badge, stale-list refresh on switch | `e2e/runtime-rootless.spec.ts` or a dedicated spec | 🚧 (manually verified on `fedora-full`; not yet automated — needs a project with both sockets *and* admin access, see `loginWithAdminAccess` in `e2e/helpers/admin.ts`) |
-| superuser prompt | Compose file owned by another uid (`composeFileSuperuser()`, `src/api/cockpit.ts:185-215`) | `e2e/superuser-prompt.spec.ts` | 🚧 |
-| distro quirks | Debian cgroupfs pause/unpause workaround, Fedora SELinux `label=false`, pasta/nftables networking | covered implicitly by running Wave-1 lifecycle specs against the full matrix rather than a dedicated spec | 🚧 |
+| 7.5 | Neither runtime present — error state | `e2e/runtime-unavailable.spec.ts` | ✅ (`arch-docker`; hides both `docker` and the standalone `docker-compose` legacy binary via SSH — hiding `docker` alone isn't enough, `detectComposeCommand()` falls back to it) |
+| Rootless/Rootful socket-mode toggle (added alongside #242's fix) — switching modes when both sockets are detected, footer badge, stale-list refresh on switch | `e2e/socket-mode-toggle.spec.ts` | ✅ (`fedora-full` only, via `loginWithAdminAccess` — Rootful stays disabled without real admin access) |
+| superuser prompt | Compose file owned by another uid (`composeFileSuperuser()`, `src/api/cockpit.ts:185-215`) | `e2e/superuser-prompt.spec.ts` | ✅ (`fedora-full` only — the one VM with a genuine rootless Docker socket; see spec header comment for why a stricter-permissions fixture was tried and reverted) |
+| distro quirks | Debian cgroupfs pause/unpause workaround, Fedora SELinux `label=false`, pasta/nftables networking | covered implicitly by running Wave-1 lifecycle specs against the full matrix rather than a dedicated spec | ✅ partial — `e2e/stacks.spec.ts` + `stack-lifecycle.spec.ts` run clean on `debian-podman` (4/4 + 9/9) and `debian-docker` (13/13); `fedora-podman` 12/13 (1 known host-load flake, passed alone); `fedora-docker` 4/13 — the other 9 failures are **not** distro-quirk test gaps, they're issue [#272](https://github.com/RXTX4816/cockpit-compose/issues/272) (a real app-level race, also reproduces on `arch-docker`, not Fedora-specific) / 🚧 `debian-both`, `fedora-both` |
 
 ## Wave 3 — Edge cases / error states
 
@@ -145,6 +145,35 @@ scenarios).
     than the `podman-compose` (Python) provider `arch-podman` uses — a
     legitimate difference in what "the podman external provider" means
     per-distro/install, not a misconfiguration.
+  - Attempted a dedicated admin-access variant of the four skipped tests
+    (`loginWithAdminAccess` + Bulk Down under Rootful Docker): the
+    underlying escalation capability is already proven working elsewhere
+    (`e2e/superuser-prompt.spec.ts` on `fedora-full`), but on `arch-both`
+    specifically the very first "Up" click after `loginWithAdminAccess`
+    only ever registered as a hover (the row's tooltip appeared, no confirm
+    dialog) — combined with a "Cockpit admin mode mismatch" banner
+    (`DownedStacksSection.tsx`'s intentional warning for scanning inside the
+    admin user's own home directory, not a bug) muddying the picture. Left
+    unfixed rather than shipping a test that doesn't reliably pass — the
+    gap documented above stands; a real follow-up should probably scan a
+    directory outside the admin user's home to sidestep the mismatch banner
+    entirely before re-attempting.
+- **Issue [#272](https://github.com/RXTX4816/cockpit-compose/issues/272)** (found running the distro-quirks matrix on `fedora-docker`):
+  clicking **Close** on the Up progress modal the instant it becomes
+  clickable can silently discard a still-finishing `docker compose up` —
+  the modal shows the full success log through "Started" but the
+  container never actually exists (`docker ps -a` empty, zero `docker
+  events` activity). Rigorously reproduced with matched-timing
+  before/after comparisons (3 runs each) on `fedora-docker` and
+  `arch-docker`; does **not** reproduce on `debian-docker` or
+  `arch-podman` despite `arch-docker`/`debian-docker` having *identical*
+  Docker and Compose versions — ruled out cgroup driver and
+  version as the differentiator. Root cause not confirmed (best working
+  theory: a `cockpit.spawn` channel-close timing race, not something
+  fixable from this repo alone) — filed with the full repro rather than
+  guessing further. This is *why* `fedora-docker` only passed 4/13 in the
+  distro matrix above: the other 9 failures are all this same bug hitting
+  `upStack()`'s Close click, not per-test gaps.
 - **Second pass on Wave 3/4 remainder findings**:
   - `e2e/yaml-editor.spec.ts`'s malformed-YAML test joins the same
     host-load flake class noted above: passes reliably in isolation but can

--- a/e2e/runtime-unavailable.spec.ts
+++ b/e2e/runtime-unavailable.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
+import { sshExec } from './helpers/vm';
+
+/**
+ * Regression coverage for docs/testing.md §7.5: neither Docker nor Podman
+ * present at all. `arch-docker` never has Podman installed to begin with, so
+ * temporarily hiding its real `docker` AND `docker-compose` binaries via SSH
+ * (always restored in a `finally`) genuinely reproduces "neither compose
+ * tool present" — not a mock. (`docker` alone isn't enough:
+ * detectComposeCommand() falls back to the standalone `docker-compose`
+ * legacy binary when `docker compose` fails.)
+ */
+test('With neither runtime installed, the app shows real not-found state instead of hanging or crashing', async ({ pluginPage: page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'arch-docker', 'only arch-docker has no Podman at all, so hiding Docker alone reproduces "neither present"');
+  test.setTimeout(60_000);
+
+  // detectComposeCommand() falls back to the standalone `docker-compose`
+  // legacy binary if `docker compose` fails — hiding only `docker` still
+  // leaves detection satisfied via that fallback, so both must go.
+  await sshExec('arch-docker', 'sudo mv /usr/bin/docker /usr/bin/docker.e2e-disabled && sudo mv /usr/bin/docker-compose /usr/bin/docker-compose.e2e-disabled');
+  try {
+    await page.reload();
+
+    // Docker missing on initial load auto-suggests switching to Podman
+    // (App.tsx's dockerMissing -> suggestPodman).
+    const suggestModal = page.getByRole('dialog', { name: 'Switch to Podman' });
+    await expect(suggestModal).toBeVisible({ timeout: 15000 });
+    await expect(suggestModal.getByText('Docker was not found', { exact: false })).toBeVisible();
+    await suggestModal.getByRole('button', { name: 'Continue', exact: true }).click();
+
+    // Real effect: switching to Podman ALSO genuinely fails detection here
+    // (this VM never had Podman installed) — reverts to Docker with a real
+    // "not found" warning, not a silent hang or crash.
+    await expect(page.getByText('Podman not found', { exact: false })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: 'Docker', exact: true })).toHaveAttribute('aria-pressed', 'true');
+
+    // Real effect: the Docker *daemon*/socket is untouched by hiding the CLI
+    // binaries (dockerd keeps running), so the socket-mode toggle still
+    // correctly shows Rootful as available — but the actual listStacks call
+    // genuinely fails since there's no compose CLI left to run it with,
+    // surfacing a real error+Retry rather than an empty "nothing running"
+    // list that would be indistinguishable from a healthy, idle install.
+    await expect(page.getByText('Failed to load stacks', { exact: false })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Retry', exact: true })).toBeVisible();
+  } finally {
+    await sshExec('arch-docker', 'sudo mv /usr/bin/docker.e2e-disabled /usr/bin/docker && sudo mv /usr/bin/docker-compose.e2e-disabled /usr/bin/docker-compose');
+  }
+});

--- a/e2e/socket-mode-toggle.spec.ts
+++ b/e2e/socket-mode-toggle.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
+import { loginWithAdminAccess } from './helpers/admin';
+import { baseData } from './helpers/base';
+
+/**
+ * Regression coverage added alongside #242's fix: switching Rootless<->Rootful
+ * socket mode when both are genuinely detected. Needs a VM with both Docker
+ * sockets present *and* real Cockpit Administrative access (Rootful is
+ * disabled without it) — `fedora-full` is the one VM built for this.
+ */
+test('Switching socket mode between Rootless and Rootful actually changes which engine is queried', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'fedora-full', 'needs a VM with both Docker sockets detected and real Cockpit admin access');
+  test.setTimeout(60_000);
+
+  await loginWithAdminAccess(page);
+  await baseData(page);
+
+  const footer = page.locator('.cc-footer');
+  const socketGroup = page.getByRole('group', { name: 'Socket mode' });
+  const rootlessToggle = socketGroup.getByRole('button', { name: 'Rootless', exact: true });
+  const rootfulToggle = socketGroup.getByRole('button', { name: 'Rootful', exact: true });
+
+  // Both must be genuinely selectable — this is exactly what's broken
+  // without Administrative access (Rootful stays disabled).
+  await expect(rootlessToggle).toBeEnabled();
+  await expect(rootfulToggle).toBeEnabled();
+  await expect(footer.getByText('Rootless', { exact: true })).toBeVisible();
+
+  await rootfulToggle.click();
+  // Real effect: the footer badge flips, and the stack list is a fresh query
+  // against the rootful engine (not a stale rootless-fetched list still on
+  // screen) — docs/testing.md's "stale-list refresh on switch".
+  await expect(footer.getByText('Rootful', { exact: true })).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('.dss-stack-name').first()).toBeVisible({ timeout: 10000 });
+
+  await rootlessToggle.click();
+  await expect(footer.getByText('Rootless', { exact: true })).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('.dss-stack-name').first()).toBeVisible({ timeout: 10000 });
+});

--- a/e2e/stacks.spec.ts
+++ b/e2e/stacks.spec.ts
@@ -137,12 +137,18 @@ test('Expanded row\'s image link shows a real warning modal with the actual dest
 // shells out to — not a mocked network error, the real CLI call really fails.
 // Always restored in `finally` even if an assertion throws, since this
 // otherwise leaves the VM's podman broken for every subsequent test.
-test('A real poll failure shows the load-failed alert, and Retry recovers once the runtime is fixed', async ({ pluginPage: page }) => {
+test('A real poll failure shows the load-failed alert, and Retry recovers once the runtime is fixed', async ({ pluginPage: page }, testInfo) => {
   test.setTimeout(60_000);
   await baseData(page);
   await expect(page.locator('.dss-stack-name').first()).toBeVisible();
 
-  await sshExec('arch-podman', 'sudo mv /usr/bin/podman /usr/bin/podman.e2e-disabled');
+  // Break whichever runtime is actually active on this VM/project — podman
+  // on podman-only VMs (baseData's dismissStartupPodmanPrompt already
+  // switched to it), docker everywhere else.
+  const runtime = await page.getByRole('button', { name: 'Podman', exact: true }).getAttribute('aria-pressed') === 'true'
+    ? 'podman' : 'docker';
+  const vm = testInfo.project.name;
+  await sshExec(vm, `sudo mv /usr/bin/${runtime} /usr/bin/${runtime}.e2e-disabled`);
   try {
     // No manual refresh control exists for the main poll — the 500ms
     // auto-refresh interval (src/components/StacksView/index.tsx) will hit
@@ -157,7 +163,7 @@ test('A real poll failure shows the load-failed alert, and Retry recovers once t
     await retry.click();
     await expect(alert).toBeVisible({ timeout: 10000 });
   } finally {
-    await sshExec('arch-podman', 'sudo mv /usr/bin/podman.e2e-disabled /usr/bin/podman');
+    await sshExec(vm, `sudo mv /usr/bin/${runtime}.e2e-disabled /usr/bin/${runtime}`);
   }
 
   // Real effect: fixing the runtime and retrying actually recovers — the

--- a/e2e/superuser-prompt.spec.ts
+++ b/e2e/superuser-prompt.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
+import { loginWithAdminAccess } from './helpers/admin';
+import { baseData } from './helpers/base';
+import { ensureDown, stackRow, downStack } from './helpers/stacks';
+
+/**
+ * Regression coverage for `composeFileSuperuser()` (src/api/cockpit.ts:334-344):
+ * a compose file/directory owned by another uid (root, here — world-readable,
+ * matching how a stack originally deployed by a root cron job or system
+ * service would realistically look) needs superuser escalation to actually
+ * bring up under rootless Docker, even though the socket itself needs none.
+ *
+ * Only meaningful where Docker's rootless (per-user) socket is genuinely
+ * configured — `fedora-full` is the one VM with a real
+ * `/run/user/<uid>/docker.sock`; every other project either has no rootless
+ * Docker socket at all or defaults to Podman, whose escalation is governed
+ * purely by socket mode (see stackSuperuser's comment), not file ownership.
+ *
+ * A tighter fixture (compose file genuinely unreadable to non-root) was tried
+ * first but broke stack *discovery* itself: the scan's readComposeFile()
+ * (`cat path`, src/api/files.ts:13-15) never requests escalation at all, so a
+ * truly-unreadable file makes the stack invisible before Up is ever reachable
+ * — a real asymmetry (escalation is wired up for write actions but not the
+ * scan's own read), worth a follow-up, not something a single e2e case can
+ * exercise meaningfully without becoming a test of "this stack never appears."
+ *
+ * Fixture: `testcompose/superuser-test` (docker-compose.yml, nginx:alpine on
+ * :8099), created root-owned via SSH — not part of the shared cloud-init
+ * provisioning since it's specific to this one regression.
+ */
+test('Compose file owned by root: Administrative access lets Up escalate and actually start it', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'fedora-full', 'needs a VM with a genuine rootless Docker socket — only fedora-full has one configured');
+  test.setTimeout(60_000);
+  await loginWithAdminAccess(page);
+  await baseData(page);
+  await ensureDown(page, 'superuser-test');
+
+  const downed = page.locator('[data-status="down"]').filter({ has: page.locator('#dss-name-superuser-test') });
+  await expect(downed).toBeVisible({ timeout: 10000 });
+  await downed.getByRole('button', { name: 'Up', exact: true }).click();
+  await page.getByRole('dialog', { name: /Confirm up.*superuser-test/ }).getByRole('button', { name: 'Up', exact: true }).click();
+  const progress = page.getByRole('dialog', { name: /^Up.*superuser-test/ });
+  await progress.getByRole('button', { name: 'Close' }).click({ timeout: 30000 });
+
+  // Real effect: the container actually started under the escalated command
+  // against the root-owned compose directory — not just a UI success message
+  // papering over a silent failure.
+  await expect(stackRow(page, 'superuser-test')).toHaveAttribute('data-status', /running|partial/, { timeout: 15000 });
+  await downStack(page, 'superuser-test');
+});


### PR DESCRIPTION
## Summary
Test-only change (no production `src/` code touched), continuing from #271.

- **`e2e/runtime-unavailable.spec.ts`** (§7.5) — neither runtime present, on `arch-docker` with both `docker` and the standalone `docker-compose` legacy binary hidden via SSH (hiding `docker` alone isn't enough — `detectComposeCommand()` falls back to it).
- **`e2e/superuser-prompt.spec.ts`** — `composeFileSuperuser()` escalation for a root-owned compose file, on `fedora-full` (the one VM with a genuine rootless Docker socket).
- **`e2e/socket-mode-toggle.spec.ts`** — Rootless↔Rootful switching via `loginWithAdminAccess`, on `fedora-full`.
- **Bug fix in `e2e/stacks.spec.ts`**: the poll-failure test hardcoded `'arch-podman'` in its `sshExec` calls regardless of which VM was actually running — meaning it silently no-op'd on every other project. Now targets whichever runtime is actually active via `testInfo.project.name`.
- **7.2/7.3 verified equivalent** on `arch-podman`: confirmed via SSH that its "podman compose external provider" genuinely *is* `/usr/bin/podman-compose` (a Python script) — both rows already covered by the existing suite, no dedicated spec needed.
- **Distro matrix**: ran `stacks.spec.ts` + `stack-lifecycle.spec.ts` against `debian-podman` (clean), `debian-docker` (clean), `fedora-podman` (clean, 1 known host-load flake). `fedora-docker` surfaced a real app bug — filed as #272: closing the Up modal immediately after it reports success can discard a still-finishing `docker compose up`, reproduced with a rigorous matched-timing comparison across 4 VMs (also affects `arch-docker`, not Fedora-specific; root cause not yet confirmed).
- Attempted and abandoned an admin-access variant of `bulk-actions.spec.ts`'s Docker-default tests on `arch-both` — hit an unrelated interaction issue specific to that VM; documented rather than shipped as an unreliable test, since the underlying escalation capability is already proven by `superuser-prompt.spec.ts`.

## Test plan
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] Every new test run 3+ times for stability on its target VM
- [x] `stacks.spec.ts`'s poll-failure fix verified on both `arch-podman` and `debian-podman`
- [x] #272 reproduced with a controlled, matched-timing comparison (3 runs per branch per VM) across `fedora-docker`, `arch-docker`, `debian-docker`, `arch-podman` before filing