### PR TITLE
test: debug the 5 flaky specs (4 real bugs found), add rootful status-agreement coverage

### DIFF
--- a/docs/wiki/E2E-Test-Inventory.md
+++ b/docs/wiki/E2E-Test-Inventory.md
@@ -30,12 +30,12 @@ make this practical (`baseData`, `stacks.ts`, `runtime.ts`).
 | 6.13 | Stack info (services/images/volumes/networks tabs, shared networks) | `e2e/stack-info.spec.ts` | ✅ (found & fixed a real bug — see Notes) / 🚧 shared-networks case still open |
 | 6.14 | Edit YAML (multi-file tabs, add/delete file, import, snapshot history/diff/restore) | `e2e/yaml-editor.spec.ts` | ✅ partial / 🚧 multi-file + snapshots |
 | 6.15 | Edit env file (table/raw modes, duplicate-key warning, add file) | `e2e/env-editor.spec.ts` | ✅ (found a real doc/behavior mismatch — see Notes) |
-| 6.16.1 | Prune — basic flow (containers; volumes appears unreachable via UI, see reference doc) | `e2e/prune.spec.ts` | ✅ |
+| 6.16.1 | Prune — basic flow (containers; volumes appears unreachable via UI, see reference doc) | `e2e/prune.spec.ts` | ⚠️ image/shared-image prune tests pass; container-prune tests marked `test.fixme` on Podman pending issue [#274](https://github.com/RXTX4816/cockpit-compose/issues/274) — see Notes |
 | 6.17 | Scale services (increase replicas, port-conflict warning) | `e2e/scale.spec.ts` | ✅ |
 | 6.19 | Create stack (template method, validation bypass) | `e2e/create-stack.spec.ts` | ✅ (manual method only — template/git method still 🚧) |
 | downed-stacks bulk actions (select-all + bulk Up, commit 85fe38d) | Bulk select/Up on downed stacks table | `e2e/downed-stacks-bulk.spec.ts` | ✅ |
 | 6.22 | Ports — clickable link, localhost-only vs all-interfaces tooltip | `e2e/ports.spec.ts` | ✅ (external-bind case; found a doc/behavior mismatch — see Notes) / 🚧 localhost/specific-bind cases |
-| adversarial | Malformed YAML, nonexistent scan directory, scan-depth bounds | `e2e/adversarial.spec.ts` | ⚠️ (depth/nonexistent-dir confirmed clean; malformed-YAML logic verified correct but has an unresolved host-contention-triggered flake) |
+| adversarial | Malformed YAML, nonexistent scan directory, scan-depth bounds | `e2e/adversarial.spec.ts` | ✅ all 3 fixed and stable (3/3 × 2 full-file runs) — see Notes, these were real test bugs, not flakes |
 
 ## Wave 2 — Runtime/engine-specific, full 9-VM matrix
 
@@ -48,10 +48,11 @@ Run these against the full matrix (batched per §"Managing resource usage" in
 | 7.1 | Docker rootless mode | `e2e/runtime-rootless.spec.ts` | ✅ partial (`rootless-compose-root.spec.ts`) / 🚧 |
 | 7.2 | Podman via `podman compose` external provider | (every spec that runs against `arch-podman`) | ✅ — on `arch-podman`, `podman compose`'s "external compose provider" genuinely *is* `/usr/bin/podman-compose` (verified via SSH: `podman compose version` prints the "Executing external compose provider" banner naming that exact binary); every Wave 1/3/4 spec already run against this VM exercises this path, no dedicated spec needed |
 | 7.3 | Podman via `podman-compose` (Python, no docker-compose) | (every spec that runs against `arch-podman`) | ✅ — same finding as 7.2: `arch-podman` has no `docker-compose` at all and its `podman-compose` is confirmed genuine Python (`/usr/bin/podman-compose` is `#!/usr/bin/python`, reports `podman-compose version 1.6.0`), so 7.2 and 7.3 are literally the same code path on this VM, both already covered by the existing suite |
-| 7.4 | Podman root (system socket), no rootless socket at all — issue [#242](https://github.com/RXTX4816/cockpit-compose/issues/242) regression: discovery + Stack Info container list under real Cockpit Administrative access | `e2e/runtime-rootless.spec.ts` (`fedora-podman-rootful` only) | ✅ |
+| 7.4 | Podman root (system socket), no rootless socket at all — issue [#242](https://github.com/RXTX4816/cockpit-compose/issues/242) regression: discovery + Stack Info container list under real Cockpit Administrative access, and that the two agree on state *at the same moment* after a real transition (Troubleshooting.md's status-agreement regression) | `e2e/runtime-rootless.spec.ts` (`fedora-podman-rootful` only) | ✅ |
 | 7.5 | Neither runtime present — error state | `e2e/runtime-unavailable.spec.ts` | ✅ (`arch-docker`; hides both `docker` and the standalone `docker-compose` legacy binary via SSH — hiding `docker` alone isn't enough, `detectComposeCommand()` falls back to it) |
 | Rootless/Rootful socket-mode toggle (added alongside #242's fix) — switching modes when both sockets are detected, footer badge, stale-list refresh on switch | `e2e/socket-mode-toggle.spec.ts` | ✅ (`fedora-full` only, via `loginWithAdminAccess` — Rootful stays disabled without real admin access) |
 | superuser prompt | Compose file owned by another uid (`composeFileSuperuser()`, `src/api/cockpit.ts:185-215`) | `e2e/superuser-prompt.spec.ts` | ✅ (`fedora-full` only — the one VM with a genuine rootless Docker socket; see spec header comment for why a stricter-permissions fixture was tried and reverted) |
+| Recheck button vs. a socket that exists but doesn't respond (`checkSocketHealth()`, `docs/wiki/Troubleshooting.md`) | none | 🚧 not attempted — the only way to produce this state is mutating a shared VM's live `systemd --user` socket/service, which isn't reproducible and would need a full VM reset afterward; needs a dedicated VM image provisioned with a genuinely broken/stub socket baked into cloud-init instead of a live hack, out of scope for this pass |
 | distro quirks | Debian cgroupfs pause/unpause workaround, Fedora SELinux `label=false`, pasta/nftables networking | covered implicitly by running Wave-1 lifecycle specs against the full matrix rather than a dedicated spec | ✅ partial — `e2e/stacks.spec.ts` + `stack-lifecycle.spec.ts` run clean on `debian-podman` (4/4 + 9/9) and `debian-docker` (13/13); `fedora-podman` 12/13 (1 known host-load flake, passed alone); `fedora-docker` 4/13 — the other 9 failures are **not** distro-quirk test gaps, they're issue [#272](https://github.com/RXTX4816/cockpit-compose/issues/272) (a real app-level race, also reproduces on `arch-docker`, not Fedora-specific) / 🚧 `debian-both`, `fedora-both` |
 
 ## Wave 3 — Edge cases / error states
@@ -61,7 +62,7 @@ Run these against the full matrix (batched per §"Managing resource usage" in
 | 5.3 / 6.4 | Multi-service stack with profiles | covered by 6.4 above | 🚧 |
 | 5.4 / 6.14 | Multi-file compose (extra compose file) | covered by 6.14 above | 🚧 |
 | 6.16.2-6.16.6 | Prune edge cases (shared image across stacks still in use, exited one-shot container removal by name) | `e2e/prune.spec.ts` (additional cases) | ✅ |
-| 6.16.7 | Dangling named volume | `e2e/prune.spec.ts` | ❓ appears unreachable via the current UI — see `e2e/prune.spec.ts`'s header comment and [E2E Test Reference](E2E-Test-Reference.md) before attempting; worth raising as a product question first |
+| 6.16.7 | Dangling named volume | `e2e/prune.spec.ts` | ❓ the earlier "unreachable via the current UI" finding turned out to rest on a false premise specific to Podman — see issue [#274](https://github.com/RXTX4816/cockpit-compose/issues/274) and `e2e/prune.spec.ts`'s header comment; revisit once #274 is fixed before deciding whether this is still a product question |
 | 6.18 | Backup & restore (archive create, restore into new dir, restored stack starts) | `e2e/backup-restore.spec.ts` | ✅ (found & documented a UX asymmetry vs BackupModal — see Notes) |
 | 6.14 (malformed) | Save rejects invalid YAML with error details | `e2e/yaml-editor.spec.ts` (additional case) | ✅ (see Notes for a known flake under cumulative session load) |
 | 6.23 | Clickable external links show a warning modal before navigating | `e2e/stacks.spec.ts` (additional case) | ✅ — not in StackInfoModal (its port badges call `window.open()` directly, no confirmation, see #260/`ports.spec.ts`); the real warning-modal flow is `ContainerTable`'s per-service image link inside an expanded row, covered here instead |
@@ -85,21 +86,51 @@ scenarios).
 
 ## Notes
 
-- **Known intermittent flakes surfaced during a full-suite regression pass**
-  (`e2e/adversarial.spec.ts`'s 3 tests, `e2e/backup-restore.spec.ts`,
-  `e2e/prune.spec.ts`'s `volumes-test` case): after several hours of continuous
-  VM use, these occasionally fail on `force: true` clicks racing a React
-  re-render (the target element gets replaced mid-retry, e.g.
-  `openYamlEditor`'s "Edit compose file" button) or on an async-disabled
-  button not re-enabling within its timeout (`RestoreModal`'s Restore button).
-  Confirmed NOT tied to the #259/#260/#261 merge: `e2e/stack-info.spec.ts`,
-  which directly exercises the #259 fix, passes cleanly and repeatably on the
-  same rebuilt VM. Each of the 5 passed individually earlier in this same pass
-  when run in isolation right after being written — this is the same
-  host-load/UI-timing flake class already called out for `adversarial.spec.ts`
-  in the table above and for the Background Tasks log-modal interaction (see
-  Wave 4 notes below), not a logic regression. Worth a focused pass with
-  devtools attached rather than more blind selector/timeout changes.
+- **The 5 "flaky" specs, actually debugged with a trace/screenshot pass** — of
+  the 5 specs previously tagged as an unresolved host-contention flake class,
+  4 turned out to be real, deterministic bugs (in the tests, and in one case
+  the app), not timing flakes at all:
+  - `e2e/adversarial.spec.ts`'s malformed-YAML test used
+    `page.getByRole('dialog', { name: 'Confirm save' })` — the modal's real
+    accessible name is its `ModalHeader` title ("Save with issues?"), which
+    takes ARIA precedence over the `aria-label` prop. Fixed to filter by
+    visible content instead. A second, separate bug in the same test: after
+    canceling the confirm dialog, it called `openYamlEditor()` again to
+    verify the on-disk content — but Cancel only exits edit mode, it doesn't
+    close the modal, so the second open raced the first modal's own
+    backdrop. Fixed to assert directly on the still-open modal instead of
+    closing and reopening.
+  - `e2e/adversarial.spec.ts`'s other two tests (nonexistent scan dir,
+    scan-depth bounds) never called `dismissStartupPodmanPrompt()` — on a
+    podman-only VM the auto-suggest-Podman modal blocks the Import button
+    they immediately try to click. Fixed by adding the missing call.
+  - `e2e/backup-restore.spec.ts`: a prior run's restored stack directory
+    (`e2e-restored-gotify`) was never fully deleted — `downStack()` only
+    runs `compose down`, and the app's own "Delete compose file" action only
+    removes the `.yml` (not gotify's bind-mounted `data/` subdirectory), so
+    the directory survived either cleanup path and permanently disabled
+    `RestoreModal`'s Restore button on the next run (`targetExists` stays
+    true, requiring an overwrite-confirm checkbox neither run handled). Fixed
+    afterEach/setup to `rm -rf` the directory via SSH — the only way to
+    guarantee it's actually gone. Also now cleans up accumulated
+    `.bak.tar.gz` archives, which had grown to 8+ from repeated runs.
+  - `e2e/prune.spec.ts`'s `volumes-test` case surfaced a **real app bug**:
+    see issue [#274](https://github.com/RXTX4816/cockpit-compose/issues/274)
+    — `podman container prune` is a silent no-op on containers that belong
+    to a pod, which every podman-compose stack's containers are. The test's
+    old assertion (row disappears from the running list) was based on a
+    false assumption; the row actually stays "stopped" forever since the
+    containers never get removed. This is what the §6.16.7 dangling-volume
+    "unreachable" note above was built on — also revisit once #274 is fixed.
+    Both affected tests now assert the *correct* behavior (real container
+    removal, verified via Stack Info) and are marked `test.fixme` on Podman
+    referencing #274, so they'll auto-pass once fixed rather than needing a
+    rewrite. The sibling image-prune tests in the same file are unaffected
+    (different underlying command, no pod involvement).
+  - The only genuine remaining flakiness: `e2e/backup-restore.spec.ts`'s
+    final "Up" step occasionally needs more than 20s when run right after
+    several other heavy tests in the same batch (passes reliably alone) —
+    ordinary host-load timing, not a logic bug.
 - **Real bugs found and fixed while writing Wave 1 specs this pass** (proof this
   approach works — writing the test against actual app behavior, not assumptions,
   surfaces genuine issues):

--- a/e2e/adversarial.spec.ts
+++ b/e2e/adversarial.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
-import { baseData } from './helpers/base';
+import { baseData, dismissStartupPodmanPrompt } from './helpers/base';
 import { openYamlEditor, yamlEditorContent } from './helpers/stacks';
 
 // These tests deliberately feed the app bad or unexpected input — the goal
@@ -35,7 +35,11 @@ test('Saving malformed YAML warns instead of silently corrupting the compose fil
   // doesn't hard-block, it opens a "Save with issues?" confirm dialog first.
   // Under VM load the dialog shell and its Alert content can each take a
   // while to paint, so both checks need more than Playwright's default 5s.
-  const confirm = page.getByRole('dialog', { name: 'Confirm save' });
+  // Note: the modal's aria-label is "Confirm save", but its ModalHeader's
+  // aria-labelledby takes ARIA precedence for the accessible name — filter
+  // by visible content instead of fighting that (see yaml-editor.spec.ts's
+  // malformed-YAML test for the same finding).
+  const confirm = page.getByRole('dialog').filter({ hasText: 'Save with issues?' });
   await expect(confirm).toBeVisible({ timeout: 15000 });
   // .first() — both the alert heading and its body text contain "error".
   await expect(confirm.getByText(/error/i).first()).toBeVisible({ timeout: 10000 });
@@ -43,16 +47,18 @@ test('Saving malformed YAML warns instead of silently corrupting the compose fil
   // Back out instead of forcing the save — the original file must be untouched.
   await confirm.getByRole('button', { name: 'Cancel' }).click();
   await expect(confirm).not.toBeVisible();
+  // This "Cancel" only exits edit mode (back to read-only) — the modal
+  // itself stays open, so asserting on it directly here (rather than
+  // closing and reopening via openYamlEditor) avoids racing a second
+  // "Edit compose file" click against this modal's own still-visible backdrop.
   await page.getByRole('dialog').getByRole('button', { name: 'Cancel' }).click();
-
-  // Reopen fresh and confirm the on-disk content was never touched.
-  await openYamlEditor(page, 'gotify');
   await expect(yamlEditorContent(page)).toContainText('gotify');
   await expect(yamlEditorContent(page)).not.toContainText('this is not valid yaml');
   await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click();
 });
 
 test('Scanning a directory that does not exist fails gracefully instead of crashing', async ({ pluginPage: page }) => {
+  await dismissStartupPodmanPrompt(page);
   await page.getByRole('button', { name: 'Import', exact: true }).click();
   const scanInput = page.getByLabel('Compose directory');
   await scanInput.waitFor();
@@ -69,6 +75,7 @@ test('Scanning a directory that does not exist fails gracefully instead of crash
 });
 
 test('Scan-depth stepper clamps at its documented bounds (1-5) instead of going out of range', async ({ pluginPage: page }) => {
+  await dismissStartupPodmanPrompt(page);
   await page.getByRole('button', { name: 'Import', exact: true }).click();
   await page.getByLabel('Compose directory').waitFor();
 

--- a/e2e/backup-restore.spec.ts
+++ b/e2e/backup-restore.spec.ts
@@ -1,20 +1,39 @@
 import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
 import { baseData } from './helpers/base';
 import { downStack, downedCard, ensureDown, stackRow } from './helpers/stacks';
+import { sshExec } from './helpers/vm';
 
 const BACKUP_DIR = '/home/test/testcompose';
 const RESTORE_NAME = 'e2e-restored-gotify';
 
 // `gotify` (see scripts/test-vm.config.sh) is a simple single-service fixture
 // safe to back up and restore under a new name/directory.
-test.afterEach(async ({ pluginPage: page }) => {
+//
+// Teardown must delete the restored *directory*, not just stop the stack —
+// downStack() only runs `compose down`, and the app's own "Delete compose
+// file" action only removes the .yml (not gotify's bind-mounted `data/`
+// subdirectory), so the directory itself survives either cleanup path. A
+// prior run's leftover directory made RestoreModal's `targetExists` check
+// trip on the next run, permanently disabling its Restore button (it
+// requires an overwrite-confirm checkbox neither this test nor the
+// unsuspecting next run handled) — a real self-inflicted state leak, not a
+// flake. `rm -rf` via SSH is the only way to guarantee it's actually gone.
+test.afterEach(async ({ pluginPage: page }, testInfo) => {
   if (await stackRow(page, RESTORE_NAME).count()) {
     await downStack(page, RESTORE_NAME).catch(() => {});
   }
+  await sshExec(testInfo.project.name, `rm -rf ${BACKUP_DIR}/${RESTORE_NAME}`).catch(() => {});
+  // Each run creates a real timestamped .bak.tar.gz in BACKUP_DIR — left
+  // uncleaned across many runs, RestoreModal's archive list (and Rescan)
+  // just keeps growing for no test benefit.
+  await sshExec(testInfo.project.name, `rm -f ${BACKUP_DIR}/gotify-*.bak.tar.gz`).catch(() => {});
 });
 
-test('Backup creates a real archive on disk, and Restore recreates a runnable stack from it', async ({ pluginPage: page }) => {
+test('Backup creates a real archive on disk, and Restore recreates a runnable stack from it', async ({ pluginPage: page }, testInfo) => {
   test.setTimeout(90_000);
+  // Self-heal against a previous interrupted run's leaked restore directory
+  // (see afterEach's comment) before assuming the target path is free.
+  await sshExec(testInfo.project.name, `rm -rf ${BACKUP_DIR}/${RESTORE_NAME}`).catch(() => {});
   await baseData(page);
   await ensureDown(page, 'gotify');
 

--- a/e2e/prune.spec.ts
+++ b/e2e/prune.spec.ts
@@ -7,28 +7,31 @@ import { downedCard, downStack, ensureDown, stackRow, upStack } from './helpers/
 // stays in the running-stacks list with its per-stack Prune action, matching
 // testing guide §6.16.1.
 //
-// NOTE on volume pruning specifically (§6.16.7 "dangling named volume"):
-// this scenario looks unreachable through the current UI. Volume detection
-// (src/api/stacks.ts listDanglingVolumes()) runs a plain
-// `docker volume ls --filter dangling=true` — Docker's own definition,
-// which only counts a volume as dangling once *no container at all*
-// (running or stopped) references it. But the per-stack Prune action only
-// exists on a row in the *running* stacks list, and that row disappears
-// (moves to the downed-stacks section, which has no Prune action) the
-// moment the stack's container count hits zero — verified live: pruning
-// volumes-test's stopped containers via this same modal made the row
-// vanish immediately, before a second Prune pass to target the now-truly-
-// dangling volume could ever be reached. In other words, by the time a
-// volume qualifies as prunable, the UI no longer offers a way to prune it
-// for that stack. Flagged as a product question, not fixed here — see
-// docs/wiki/E2E-Test-Reference.md's "Known flaky behavior" section.
+// NOTE on volume pruning specifically (§6.16.7 "dangling named volume"): an
+// earlier pass's assumption here — that pruning volumes-test's stopped
+// containers makes the row disappear immediately, leaving no UI path to
+// reach the now-dangling volume — turned out to rest on a false premise on
+// Podman: see issue #274. Prune Containers is a silent no-op there (the
+// `podman container prune` command it shells out to categorically ignores
+// containers that belong to a pod, which every podman-compose stack's
+// containers are), so the row never actually loses its containers and never
+// moves to the downed section at all. Whether the dangling-volume UI gap
+// is real on Docker (where no pod concept exists) is still untested —
+// worth revisiting once #274 is fixed and Podman's Prune Containers can be
+// trusted to reflect what it claims to do.
 test.afterEach(async ({ pluginPage: page }) => {
   if (await stackRow(page, 'volumes-test').count()) {
     await downStack(page, 'volumes-test').catch(() => {});
   }
 });
 
-test('Prune removes real stopped containers, not just closes the dialog', async ({ pluginPage: page }) => {
+test('Prune removes real stopped containers, not just closes the dialog', async ({ pluginPage: page }, testInfo) => {
+  // Genuinely broken on Podman — see #274 (podman container prune is a
+  // silent no-op on pod-member containers, which every podman-compose
+  // stack's containers are). Kept asserting the *correct* behavior rather
+  // than weakened to match the bug, so this starts passing again the moment
+  // #274 is fixed instead of needing to be rewritten.
+  test.fixme(testInfo.project.name.includes('podman'), 'podman container prune is a no-op on pod-member containers — see #274');
   // See logs.spec.ts for why: Up alone can eat most of the default 30s.
   test.setTimeout(120_000);
   await baseData(page);
@@ -54,14 +57,29 @@ test('Prune removes real stopped containers, not just closes the dialog', async 
 
     const previewModal = page.getByRole('dialog', { name: /Confirm prune — volumes-test/ });
     await expect(previewModal).toBeVisible();
-    // Real effect target: the stopped db container listed by name, not just a generic count.
-    await expect(previewModal.getByText('volumes-test-db-1', { exact: false })).toBeVisible({ timeout: 10000 });
+    // Real effect target: the stopped db container listed by name, not just a
+    // generic count. Podman container names use underscores as the
+    // service/index separators (project name's own hyphen is untouched).
+    await expect(previewModal.getByText('volumes-test_db_1', { exact: false })).toBeVisible({ timeout: 10000 });
     await previewModal.getByRole('button', { name: 'Prune selected' }).click();
     await expect(previewModal).not.toBeVisible({ timeout: 20000 });
 
-    // Real effect check: the stack now has zero containers, so it drops out
-    // of the running-stacks list entirely (moves to the downed section).
-    await expect(row).toHaveCount(0, { timeout: 15000 });
+    // Real effect check: the stack itself does NOT drop out of the
+    // running-stacks list — `compose ls` (podman and docker alike) still
+    // lists a known project even with zero containers, so it stays visible
+    // here as "stopped". Its "N services" count also doesn't change (that
+    // reflects the compose *file's* defined services, not live container
+    // count). (Earlier versions of this test assumed the row would
+    // disappear, or that the services count would drop to 0 — both verified
+    // false against the real DOM/app behavior.) Stack Info is the one place
+    // that actually reflects live container state, so that's what proves
+    // the containers are really gone.
+    await expect(row).toHaveAttribute('data-status', 'stopped', { timeout: 15000 });
+    await row.getByRole('button', { name: 'Stack info' }).click();
+    const infoModal = page.getByRole('dialog', { name: /Info — volumes-test/ });
+    await expect(infoModal).toBeVisible();
+    await expect(infoModal.locator('.sim-no-containers')).toBeVisible({ timeout: 10000 });
+    await infoModal.getByRole('button', { name: 'Close' }).click();
   } finally {
     if (await row.count()) {
       await downStack(page, 'volumes-test').catch(() => {});
@@ -139,7 +157,13 @@ test('Prune does not offer to remove an image another stack is still using', asy
 // `exited-containers_prunetest` (testing guide §6.16.6) exits immediately
 // (restart: "no"), giving Prune's Containers section a real stopped
 // container to list and remove by name.
-test('Prune removes a real one-shot exited container by name', async ({ pluginPage: page }) => {
+test('Prune removes a real one-shot exited container by name', async ({ pluginPage: page }, testInfo) => {
+  // Genuinely broken on Podman — see #274 (podman container prune is a
+  // silent no-op on pod-member containers, which every podman-compose
+  // stack's containers are). This test previously only checked the preview
+  // modal and that "Prune selected" closed it, never that the container was
+  // actually gone afterward — which is exactly how #274 went unnoticed.
+  test.fixme(testInfo.project.name.includes('podman'), 'podman container prune is a no-op on pod-member containers — see #274');
   test.setTimeout(60_000);
   await baseData(page);
   await ensureDown(page, 'exited-containers_prunetest');
@@ -171,4 +195,11 @@ test('Prune removes a real one-shot exited container by name', async ({ pluginPa
   await expect(previewModal.getByText('exited-containers_prunetest_job_1', { exact: false })).toBeVisible({ timeout: 10000 });
   await previewModal.getByRole('button', { name: 'Prune selected' }).click();
   await expect(previewModal).not.toBeVisible({ timeout: 20000 });
+
+  // Real effect: the container is actually gone, not just the modal closed.
+  await row.getByRole('button', { name: 'Stack info' }).click();
+  const infoModal = page.getByRole('dialog', { name: /Info — exited-containers_prunetest/ });
+  await expect(infoModal).toBeVisible();
+  await expect(infoModal.locator('.sim-no-containers')).toBeVisible({ timeout: 10000 });
+  await infoModal.getByRole('button', { name: 'Close' }).click();
 });

--- a/e2e/runtime-rootless.spec.ts
+++ b/e2e/runtime-rootless.spec.ts
@@ -41,5 +41,45 @@ test.describe('rootful Podman (no rootless socket)', () => {
     await expect(modal).toBeVisible();
     await expect(modal.locator('.sim-no-containers')).not.toBeVisible();
     await expect(modal.getByText(/running/i).first()).toBeVisible();
+    await modal.getByRole('button', { name: 'Close' }).click();
+  });
+
+  // docs/wiki/Troubleshooting.md: before #242's fix, the stack-level status
+  // badge and Stack Info's own container list came from two separate
+  // escalation-unaware code paths and could disagree — the row would say
+  // "stopped" while Info still listed stale "running" containers (or vice
+  // versa), because only one of the two paths had been fixed to escalate.
+  // This asserts both genuinely agree *at the same moment*, right after a
+  // real state transition — not just that each is eventually correct on
+  // its own schedule.
+  test('stack-level status and Stack Info agree on state at the same moment after a rootful transition', async ({ page }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'fedora-podman-rootful',
+      'only meaningful on the rootful-only VM — every other project has a rootless socket that would mask this',
+    );
+    test.setTimeout(60_000);
+
+    await loginWithAdminAccess(page);
+    await dismissStartupPodmanPrompt(page);
+
+    const row = stackRow(page, 'gotify');
+    await expect(row).toHaveAttribute('data-status', /running|partial/, { timeout: 15000 });
+
+    await row.getByRole('button', { name: 'Stop', exact: true }).click();
+    await page.getByRole('dialog', { name: 'Confirm stop' }).getByRole('button', { name: 'Stop', exact: true }).click();
+    await expect(row).toHaveAttribute('data-status', 'stopped', { timeout: 15000 });
+
+    // Real effect: opening Info immediately after must show the container as
+    // genuinely exited too — not a stale "running" snapshot from before Stop.
+    await row.getByRole('button', { name: 'Stack info' }).click();
+    const modal = page.getByRole('dialog', { name: /gotify/i });
+    await expect(modal).toBeVisible();
+    await expect(modal.getByText(/running/i)).toHaveCount(0);
+    await expect(modal.getByText(/exited/i).first()).toBeVisible({ timeout: 10000 });
+    await modal.getByRole('button', { name: 'Close' }).click();
+
+    // Restore for any subsequent run of the spec above.
+    await row.getByRole('button', { name: 'Start', exact: true }).click();
+    await expect(row).toHaveAttribute('data-status', /running|partial/, { timeout: 15000 });
   });
 });


### PR DESCRIPTION
## Summary
Test-only change (no production `src/` code touched), continuing from #273.

The 5 specs previously tagged as an unresolved host-contention flake class got an actual trace/screenshot debugging pass instead of more blind timeout tweaks. 4 of the 5 turned out to be real, deterministic bugs:

- **`e2e/adversarial.spec.ts`** (all 3 tests): malformed-YAML test targeted the wrong dialog name (its `aria-label` is overridden by the `ModalHeader`'s `aria-labelledby`) and separately tried to reopen a modal it never actually closed. The other two tests never dismissed the podman-only startup prompt, which was blocking the button they immediately tried to click.
- **`e2e/backup-restore.spec.ts`**: a restored stack's directory leaked across runs (neither `downStack()` nor the app's own "Delete compose file" remove the bind-mounted `data/` subdirectory), permanently disabling the Restore button on the next run. Now uses SSH for guaranteed cleanup.
- **`e2e/prune.spec.ts`**: surfaced a real app bug — filed as **#274**: `podman container prune` is a silent no-op on pod-member containers, which every podman-compose stack's containers are. Both affected tests now assert the correct behavior and are `test.fixme`'d on Podman referencing #274, so they'll auto-pass once fixed.

Also adds `e2e/runtime-rootless.spec.ts`'s stack-status-agreement regression (Troubleshooting.md: stack badge and Stack Info must agree on state *at the same moment* after a transition), verified on `fedora-podman-rootful`.

The Recheck-vs-unresponsive-socket case was investigated but not implemented — producing that state needs mutating a shared VM's live systemd state, not reproducible without a dedicated VM image; tracked as a documented gap instead.

## Test plan
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] Each fixed test run 3× individually for stability, plus 2× full-file combined runs
- [x] Issue #274 verified via direct SSH reproduction (both through the UI and running the exact underlying `podman container prune` command manually) before filing