### PR TITLE
test: fixture stacks, scan-depth, shared networks, add/delete YAML file

### DIFF
--- a/docs/wiki/E2E-Test-Inventory.md
+++ b/docs/wiki/E2E-Test-Inventory.md
@@ -27,8 +27,8 @@ make this practical (`baseData`, `stacks.ts`, `runtime.ts`).
 | 6.10 | Exec / shell into a running container | `e2e/exec.spec.ts` | ✅ |
 | 6.11 | Run command (one-off, --rm) | `e2e/run-command.spec.ts` | ✅ (args mode + --entrypoint override mode) |
 | 6.12 | Pull images (progress, unpinned warning, cancel) | `e2e/pull-images.spec.ts` | ✅ (unpinned warning + real re-pull + Run in Background) |
-| 6.13 | Stack info (services/images/volumes/networks tabs, shared networks) | `e2e/stack-info.spec.ts` | ✅ (found & fixed a real bug — see Notes) / 🚧 shared-networks case still open |
-| 6.14 | Edit YAML (multi-file tabs, add/delete file, import, snapshot history/diff/restore) | `e2e/yaml-editor.spec.ts` | ✅ (multi-file tabs + snapshot history/diff/restore covered) / 🚧 add/delete file specifically (attempted, cut for click reliability — see spec comment) |
+| 6.13 | Stack info (services/images/volumes/networks tabs, shared networks) | `e2e/stack-info.spec.ts` | ✅ (found & fixed a real bug — see Notes; shared-networks case covered by connecting a real container to another project's network via SSH) |
+| 6.14 | Edit YAML (multi-file tabs, add/delete file, import, snapshot history/diff/restore) | `e2e/yaml-editor.spec.ts` | ✅ (add/delete file found & documented a real accessibility bug — see Notes and issue [#277](https://github.com/RXTX4816/cockpit-compose/issues/277)) |
 | 6.15 | Edit env file (table/raw modes, duplicate-key warning, add file) | `e2e/env-editor.spec.ts` | ✅ (found a real doc/behavior mismatch — see Notes) |
 | 6.16.1 | Prune — basic flow (containers; volumes appears unreachable via UI, see reference doc) | `e2e/prune.spec.ts` | ⚠️ image/shared-image prune tests pass; container-prune tests marked `test.fixme` on Podman pending issue [#274](https://github.com/RXTX4816/cockpit-compose/issues/274) — see Notes |
 | 6.17 | Scale services (increase replicas, port-conflict warning) | `e2e/scale.spec.ts` | ✅ |
@@ -152,6 +152,17 @@ scenarios).
     editor is mounted, so a raw-mode-only duplicate silently saves with no warning.
     `e2e/env-editor.spec.ts` exercises the real (Table-mode) path where the check
     genuinely runs and documents the Raw-mode gap.
+  - `e2e/yaml-editor.spec.ts`'s add/delete-file case (previously cut for "unreliable"
+    Create-file clicks) turned out to have a real, reproducible cause: typing into
+    the nested "Add compose file" modal's Filename input gets both that modal's and
+    the outer `YamlModal`'s backdrop stuck at `aria-hidden="true"` — a PatternFly
+    focus-trap bug in modal-in-modal nesting. Functionally harmless to mouse/keyboard
+    users (a plain click still creates the file for real) but breaks accessible-name
+    resolution for everything inside both modals from that point on — a genuine a11y
+    regression for screen reader users. Filed as issue
+    [#277](https://github.com/RXTX4816/cockpit-compose/issues/277); the spec works
+    around it with a CSS-based click instead of `getByRole` and still verifies the
+    real effect (file genuinely created/removed on disk via SSH, not just tab count).
 - **`arch-both` findings (Wave 2, first pass)**:
   - This VM's Docker only exposes a **Rootful** socket — no rootless Docker
     at all. `bulk-actions.spec.ts`'s four pre-existing Docker-default tests

--- a/e2e/bulk-actions.spec.ts
+++ b/e2e/bulk-actions.spec.ts
@@ -95,6 +95,38 @@ test.describe('Docker-default selection behavior', () => {
     await expect(bulkBar.getByText('1 selected', { exact: false })).toBeVisible();
   });
 
+  test('Pretty layout selects stacks by clicking the card itself, not a checkbox', async ({ pluginPage: page }) => {
+    test.setTimeout(60_000);
+    await baseData(page);
+    await ensureDown(page, 'gotify');
+    await ensureDown(page, 'env-test');
+    await upStack(page, 'gotify');
+    await upStack(page, 'env-test');
+
+    await page.getByRole('button', { name: 'Change layout' }).click();
+    await page.getByRole('button', { name: 'Pretty', exact: true }).click();
+
+    // PrettyCard sets no accessible role/name of its own (unlike
+    // MinimalCard) — data-stack-name is the only reliable locator.
+    const gotifyCard = page.locator('.pc-card[data-stack-name="gotify"]');
+    const envCard = page.locator('.pc-card[data-stack-name="env-test"]');
+    await expect(gotifyCard).toBeVisible({ timeout: 10000 });
+    await gotifyCard.click();
+    await expect(gotifyCard).toHaveAttribute('aria-pressed', 'true');
+
+    const bulkBar = page.getByTestId('sv-bulk-bar');
+    await expect(bulkBar).toBeVisible();
+    await expect(bulkBar.getByText('1 selected', { exact: false })).toBeVisible();
+
+    await envCard.click();
+    await expect(bulkBar.getByText('2 selected', { exact: false })).toBeVisible();
+
+    // Clicking again deselects — real toggle, not a one-way flag.
+    await gotifyCard.click();
+    await expect(gotifyCard).toHaveAttribute('aria-pressed', 'false');
+    await expect(bulkBar.getByText('1 selected', { exact: false })).toBeVisible();
+  });
+
   test('Unix layout selects stacks via the [ ]/[x] bracket toggle', async ({ pluginPage: page }) => {
     test.setTimeout(90_000);
     await baseData(page);

--- a/e2e/fixture-stacks.spec.ts
+++ b/e2e/fixture-stacks.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
+import { baseData } from './helpers/base';
+import { downStack, downedCard, ensureDown, stackRow } from './helpers/stacks';
+
+// Parametrized real-behavior checks for the pre-staged fixture stacks that
+// exist in scripts/test-vm.config.sh but have no dedicated scenario of their
+// own in docs/testing.md §5 or the manual testing guide — folded into a
+// single spec per docs/wiki/E2E-Test-Inventory.md's plan rather than
+// duplicated across 6.1/6.13.
+
+test.afterEach(async ({ pluginPage: page }) => {
+  for (const name of ['healthcheck', 'restart-policy', 'named-networks', 'crash-loop', 'long-logs']) {
+    if (await stackRow(page, name).count()) {
+      await downStack(page, name).catch(() => {});
+    }
+  }
+});
+
+async function up(page: import('@playwright/test').Page, name: string) {
+  await downedCard(page, name).getByRole('button', { name: 'Up', exact: true }).click();
+  await page.getByRole('dialog', { name: new RegExp(`Confirm up.*${name}`) }).getByRole('button', { name: 'Up', exact: true }).click();
+  const progress = page.getByRole('dialog', { name: new RegExp(`^Up.*${name}`) });
+  await progress.getByRole('button', { name: 'Close' }).click({ timeout: 30000 });
+}
+
+test('healthcheck fixture: Stack Info reflects real healthcheck transitions, not a static label', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+  await ensureDown(page, 'healthcheck');
+  await up(page, 'healthcheck');
+
+  const row = stackRow(page, 'healthcheck');
+  await expect(row).toHaveAttribute('data-status', /running|partial/, { timeout: 15000 });
+  await row.getByRole('button', { name: 'Stack info' }).click();
+  const modal = page.getByRole('dialog', { name: /Info — healthcheck/ });
+  await expect(modal).toBeVisible();
+
+  // Real effect: the compose file's healthcheck (start_period 5s, 10s
+  // interval) genuinely converges to "healthy" — not a one-shot snapshot
+  // frozen at whatever it showed on first render. Podman folds the health
+  // state directly into the uptime text ("Up 1 second (healthy)") rather
+  // than a separate "Health" row.
+  await expect(modal.getByText('healthy', { exact: false })).toBeVisible({ timeout: 30000 });
+  await modal.getByRole('button', { name: 'Close' }).click();
+});
+
+test('restart-policy fixture: on-failure and unless-stopped behave differently for real', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+  await ensureDown(page, 'restart-policy');
+  await up(page, 'restart-policy');
+
+  const row = stackRow(page, 'restart-policy');
+  // Real effect: `flaky` (restart: on-failure, exits after 5s) keeps getting
+  // restarted rather than settling into a final "exited" state, so the
+  // stack stays partial/running rather than ever fully stopping on its own.
+  await expect(row).toHaveAttribute('data-status', /running|partial/, { timeout: 15000 });
+  await page.waitForTimeout(8000);
+  await expect(row).toHaveAttribute('data-status', /running|partial/);
+
+  await row.getByRole('button', { name: 'Stack info' }).click();
+  const modal = page.getByRole('dialog', { name: /Info — restart-policy/ });
+  await expect(modal).toBeVisible();
+  await expect(modal.getByText('stable', { exact: true })).toBeVisible();
+  await expect(modal.getByText('flaky', { exact: true })).toBeVisible();
+  await modal.getByRole('button', { name: 'Close' }).click();
+});
+
+test('named-networks fixture: Stack Info lists each real network the compose file defines', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+  await ensureDown(page, 'named-networks');
+  await up(page, 'named-networks');
+
+  const row = stackRow(page, 'named-networks');
+  await expect(row).toHaveAttribute('data-status', /running|partial/, { timeout: 15000 });
+  await row.getByRole('button', { name: 'Stack info' }).click();
+  const modal = page.getByRole('dialog', { name: /Info — named-networks/ });
+  await expect(modal).toBeVisible();
+
+  // Real effect: all 3 declared networks (dmz, app, data) actually exist and
+  // are listed — not a generic "N networks" count.
+  await expect(modal.getByText('No networks found', { exact: false })).toHaveCount(0);
+  for (const net of ['dmz', 'app', 'data']) {
+    await expect(modal.getByText(new RegExp(`named-networks_${net}\\b`))).toBeVisible({ timeout: 10000 });
+  }
+  await modal.getByRole('button', { name: 'Close' }).click();
+});
+
+test('crash-loop fixture: the crashing service actually keeps crashing, the sidecar keeps running', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+  await ensureDown(page, 'crash-loop');
+  await up(page, 'crash-loop');
+
+  const row = stackRow(page, 'crash-loop');
+  // Real effect: `crasher` (restart: on-failure, exits immediately) never
+  // reaches a steady "running" state, so the stack settles into "partial"
+  // (sidecar up, crasher cycling) rather than "running".
+  await expect(row).toHaveAttribute('data-status', 'partial', { timeout: 20000 });
+
+  await row.getByRole('button', { name: 'Stack info' }).click();
+  const modal = page.getByRole('dialog', { name: /Info — crash-loop/ });
+  await expect(modal).toBeVisible();
+  await expect(modal.getByText('sidecar', { exact: true })).toBeVisible();
+  await expect(modal.getByText('running', { exact: true }).first()).toBeVisible();
+  await modal.getByRole('button', { name: 'Close' }).click();
+});
+
+test('long-logs fixture: Logs modal streams real, continuously-growing output', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+  await ensureDown(page, 'long-logs');
+  await up(page, 'long-logs');
+
+  const row = stackRow(page, 'long-logs');
+  await expect(row).toHaveAttribute('data-status', /running|partial/, { timeout: 15000 });
+  await row.getByRole('button', { name: 'View logs' }).click();
+  const modal = page.getByRole('dialog', { name: /Logs — long-logs/ });
+  await expect(modal).toBeVisible();
+
+  // Real effect: real content streams in, and `logger`'s tight sleep-0.3s
+  // loop means a later line number is visible a few seconds after the
+  // first one — a real growing stream, not a static one-time fetch.
+  await expect(modal.getByText(/request \d+ processed/).first()).toBeVisible({ timeout: 15000 });
+  const firstLineText = await modal.getByText(/request \d+ processed/).last().textContent();
+  const firstN = Number(firstLineText?.match(/request (\d+) processed/)?.[1] ?? 0);
+  await page.waitForTimeout(3000);
+  const laterLineText = await modal.getByText(/request \d+ processed/).last().textContent();
+  const laterN = Number(laterLineText?.match(/request (\d+) processed/)?.[1] ?? 0);
+  expect(laterN).toBeGreaterThan(firstN);
+  await modal.getByRole('button', { name: 'Close' }).click();
+});

--- a/e2e/stack-info.spec.ts
+++ b/e2e/stack-info.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
 import { baseData } from './helpers/base';
-import { downStack, stackRow, withRunningStack } from './helpers/stacks';
+import { downStack, ensureDown, stackRow, upStack, withRunningStack } from './helpers/stacks';
+import { sshExec } from './helpers/vm';
 
 // `volumes-test` (db+app, db uses a named volume `pgdata` — see
 // scripts/test-vm.config.sh) gives us real services, images, volumes, and a
@@ -51,4 +52,47 @@ test('Stack Info shows real services, images, volumes, and networks — not empt
     await modal.getByRole('button', { name: 'Close' }).click();
     await expect(modal).not.toBeVisible();
   });
+});
+
+// Regression coverage for §6.13's shared-networks case: no existing fixture
+// stack pair actually shares a network by default, so this connects one of
+// `multi`'s real containers to `gotify`'s network via SSH (the same real
+// container-engine command a user's own docker/podman network connect would
+// run) — genuinely making gotify's default network cross-project, not
+// simulated in any way.
+test('Stack Info flags a network actually shared with another project', async ({ pluginPage: page }, testInfo) => {
+  test.setTimeout(90_000);
+  const vm = testInfo.project.name;
+  await baseData(page);
+  await ensureDown(page, 'gotify');
+  await ensureDown(page, 'multi');
+  await upStack(page, 'gotify');
+  await upStack(page, 'multi');
+
+  try {
+    const runtime = await page.getByRole('button', { name: 'Podman', exact: true }).getAttribute('aria-pressed') === 'true'
+      ? 'podman' : 'docker';
+    await sshExec(vm, `${runtime} network connect gotify_default multi_web_1 || ${runtime} network connect gotify_default multi-web-1`);
+
+    const row = stackRow(page, 'gotify');
+    await row.getByRole('button', { name: 'Stack info', exact: true }).click();
+    const modal = page.getByRole('dialog', { name: /Info — gotify/ });
+    await expect(modal).toBeVisible();
+
+    // Real effect: the actual other project's name appears next to the
+    // network it's genuinely connected to, with the warning icon — not a
+    // generic "shared" flag with no indication of who it's shared with.
+    await expect(modal.getByText('gotify_default', { exact: false })).toBeVisible({ timeout: 20000 });
+    // sharedWith is computed by a per-network round trip after the network
+    // list itself loads — give it a moment before polling for the text, a
+    // plain expect() alone has been observed racing this render (screenshot
+    // at "failure" already shows the correct text, the live poll just
+    // never catches it within the window).
+    await page.waitForTimeout(2000);
+    await expect(modal.locator('td', { hasText: 'multi' })).toBeVisible({ timeout: 20000 });
+    await modal.getByRole('button', { name: 'Close' }).click();
+  } finally {
+    await downStack(page, 'multi').catch(() => {});
+    await downStack(page, 'gotify').catch(() => {});
+  }
 });

--- a/e2e/stacks.spec.ts
+++ b/e2e/stacks.spec.ts
@@ -172,3 +172,41 @@ test('A real poll failure shows the load-failed alert, and Retry recovers once t
   await expect(page.getByText('Failed to load stacks', { exact: false })).not.toBeVisible({ timeout: 15000 });
   await expect(page.locator('.dss-stack-name').first()).toBeVisible({ timeout: 10000 });
 });
+
+// Regression coverage for §6.2's scan depth *setting* (distinct from its
+// clamping bounds, already covered by adversarial.spec.ts): a compose file
+// nested below the scan root must be invisible at the default depth (2) and
+// appear once depth is actually raised to reach it — proving the stepper
+// genuinely changes what `find -maxdepth` returns, not just a cosmetic
+// number. The discovered stack's name comes from its compose file's
+// *immediate parent directory* (useDownedStacksScan.ts's directory-name
+// fallback), not the top-level wrapper folder — OUTER/INNER below reflects
+// that, naming the fixture after what the scan will actually derive.
+test('Scan depth setting actually changes which compose files are found, not just clamps', async ({ pluginPage: page }, testInfo) => {
+  test.setTimeout(60_000);
+  const vm = testInfo.project.name;
+  const OUTER = 'e2e-depth-outer';
+  const INNER = 'e2e-depth-inner';
+  await sshExec(vm, `mkdir -p /home/test/testcompose/${OUTER}/${INNER} && printf 'services:\\n  app:\\n    image: nginx:alpine\\n' > /home/test/testcompose/${OUTER}/${INNER}/docker-compose.yml`);
+
+  try {
+    // baseData() already scans COMPOSE_DIR at the default depth (2) and
+    // retries the whole open-fill-submit sequence against rootless Podman's
+    // flaky panel-state resets (see its own doc comment) — more robust than
+    // a one-shot manual fill+Enter for this test's purposes.
+    await baseData(page);
+    const depthValue = page.locator('.dss-stepper-value');
+    await expect(depthValue).toHaveText('2');
+    await expect(page.locator(`#dss-name-${INNER}`)).toHaveCount(0);
+
+    // Raise to depth 3 (0=root, 1=OUTER, 2=INNER, 3=the file itself) and
+    // rescan — the nested file must now actually be discovered.
+    const plus = page.getByRole('button', { name: 'Increase scan depth' });
+    await plus.click();
+    await expect(depthValue).toHaveText('3');
+    await page.getByRole('button', { name: 'Scan', exact: true }).click();
+    await expect(page.locator(`#dss-name-${INNER}`)).toBeVisible({ timeout: 15000 });
+  } finally {
+    await sshExec(vm, `rm -rf /home/test/testcompose/${OUTER}`);
+  }
+});

--- a/e2e/yaml-editor.spec.ts
+++ b/e2e/yaml-editor.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@rxtx4816/cockpit-plugin-base-react/e2e';
 import { baseData } from './helpers/base';
 import { openYamlEditor, yamlEditorContent } from './helpers/stacks';
+import { sshExec } from './helpers/vm';
 
 test.describe('basic editor behavior (gotify, pre-opened in edit mode)', () => {
   test.beforeEach(async ({ pluginPage: page }) => {
@@ -67,6 +68,65 @@ test('Multi-file tabs show each file\'s own real content, not shared/stale conte
 
   await modal.getByRole('tab', { name: /overrides\.yml/ }).click();
   await expect(modal.locator('.cm-content')).toContainText('NGINX_HOST');
+
+  await modal.getByRole('button', { name: 'Close' }).click();
+});
+
+// A previous attempt at this scenario (see the header comment above) found
+// the "Create file" button unreliable to click. Root-caused this session:
+// typing into the nested "Add compose file" modal's filename field gets its
+// own backdrop (and the outer YamlModal's) stuck at aria-hidden="true" —
+// visually and functionally the modal keeps working fine (a plain mouse
+// click still creates the file for real), but Playwright's (and a real
+// screen reader's) accessible-name resolution can no longer see anything
+// inside it, so getByRole never resolves. This is a real PatternFly
+// focus-trap bug in modal-in-modal nesting, filed as #277 — not fixed here,
+// worked around below with a CSS-based click for the one button affected.
+test('Add file creates a real new compose file; Delete file removes it from disk', async ({ pluginPage: page }, testInfo) => {
+  test.setTimeout(60_000);
+  const vm = testInfo.project.name;
+  const EXTRA_PATH = '/home/test/testcompose/env-test/extra.yml';
+  await sshExec(vm, `rm -f ${EXTRA_PATH}`).catch(() => {});
+
+  await baseData(page);
+  await openYamlEditor(page, 'env-test');
+  const modal = page.getByRole('dialog');
+  await expect(modal.locator('[role="tab"]')).toHaveCount(1);
+
+  await modal.getByRole('button', { name: 'Add', exact: true }).click();
+  const addModal = page.getByRole('dialog').filter({ hasText: 'Add compose file' });
+  await expect(addModal).toBeVisible({ timeout: 10000 });
+  await addModal.locator('#ym-new-filename').fill('extra.yml');
+
+  // #277 workaround: after the fill above, addModal is no longer resolvable
+  // via role/name (see comment above) — target the primary footer button by
+  // CSS instead of by accessible role.
+  await page.locator('.pf-v6-c-modal-box').filter({ hasText: 'Add compose file' })
+    .locator('.pf-v6-c-button.pf-m-primary').click();
+  await expect(page.locator('.pf-v6-c-modal-box').filter({ hasText: 'Add compose file' })).toHaveCount(0, { timeout: 15000 });
+
+  // Real effect: a second tab for the real new file exists, and it's the
+  // one now active/showing its (stub) content — not just a UI state flag.
+  await expect(modal.locator('[role="tab"]')).toHaveCount(2, { timeout: 10000 });
+  await expect(modal.getByRole('tab', { name: /extra\.yml/ })).toBeVisible();
+
+  // Real effect: the file genuinely exists on disk, independent of the app.
+  const lsOut = await sshExec(vm, `test -f ${EXTRA_PATH} && echo EXISTS`);
+  expect(lsOut.trim()).toBe('EXISTS');
+
+  // --- Delete it again ---
+  await modal.getByRole('tab', { name: /extra\.yml/ }).click(); // ensure its tab is active
+  const deleteBtn = modal.locator('.ym-delete-file-btn');
+  await deleteBtn.click();
+  const deleteConfirm = page.getByRole('dialog').filter({ hasText: 'Delete extra.yml?' });
+  await expect(deleteConfirm).toBeVisible({ timeout: 10000 });
+  await deleteConfirm.getByRole('button', { name: 'Delete file', exact: true }).click();
+  await expect(deleteConfirm).not.toBeVisible({ timeout: 10000 });
+
+  // Real effect: back to one tab, and the file is genuinely gone from disk.
+  await expect(modal.locator('[role="tab"]')).toHaveCount(1, { timeout: 10000 });
+  const lsAfter = await sshExec(vm, `test -f ${EXTRA_PATH} && echo EXISTS || echo GONE`);
+  expect(lsAfter.trim()).toBe('GONE');
 
   await modal.getByRole('button', { name: 'Close' }).click();
 });


### PR DESCRIPTION
## Summary
- New `e2e/fixture-stacks.spec.ts`: parametrized real-behavior checks for the pre-staged `healthcheck`, `restart-policy`, `named-networks`, `crash-loop`, and `long-logs` fixture stacks (no dedicated coverage existed for these).
- `e2e/bulk-actions.spec.ts`: Pretty layout's card-click selection (PrettyCard has no accessible role, uses CSS `data-stack-name` locator).
- `e2e/stacks.spec.ts`: scan-depth setting's real effect on which compose files are discovered (not just its clamping bounds).
- `e2e/stack-info.spec.ts`: Stack Info flags a network genuinely shared with another project (connected via SSH `network connect`, not simulated).
- `e2e/yaml-editor.spec.ts`: Add/delete file in the YAML editor — genuinely creates/removes a file on disk, verified via SSH.
  - Found and filed a real accessibility bug: issue #277 — typing in the nested "Add compose file" modal's Filename input leaves both modal backdrops stuck at `aria-hidden="true"`, breaking accessible-name resolution (screen readers, `getByRole`) while the feature keeps functioning for mouse/keyboard users. Worked around in the spec with a CSS-based click.
- `docs/wiki/E2E-Test-Inventory.md` updated to reflect all of the above.

## Test plan
- [x] All new/modified tests run 3x individually on `arch-podman`, stable.
- [x] Full `yaml-editor.spec.ts`, `stack-info.spec.ts`, `stacks.spec.ts`, `bulk-actions.spec.ts`, `fixture-stacks.spec.ts` files run clean (one pre-existing documented flake in `yaml-editor.spec.ts`'s malformed-YAML test under cumulative session load, unrelated to this change — passes in isolation).