### PR TITLE
test: cover Create Stack's git-URL method

### DIFF
--- a/docs/wiki/E2E-Test-Inventory.md
+++ b/docs/wiki/E2E-Test-Inventory.md
@@ -32,7 +32,7 @@ make this practical (`baseData`, `stacks.ts`, `runtime.ts`).
 | 6.15 | Edit env file (table/raw modes, duplicate-key warning, add file) | `e2e/env-editor.spec.ts` | ✅ (found a real doc/behavior mismatch — see Notes) |
 | 6.16.1 | Prune — basic flow (containers; volumes appears unreachable via UI, see reference doc) | `e2e/prune.spec.ts` | ⚠️ image/shared-image prune tests pass; container-prune tests marked `test.fixme` on Podman pending issue [#274](https://github.com/RXTX4816/cockpit-compose/issues/274) — see Notes |
 | 6.17 | Scale services (increase replicas, port-conflict warning) | `e2e/scale.spec.ts` | ✅ |
-| 6.19 | Create stack (template method, validation bypass) | `e2e/create-stack.spec.ts` | ✅ (manual method only — template/git method still 🚧) |
+| 6.19 | Create stack (manual/template/git-URL methods, validation bypass) | `e2e/create-stack.spec.ts` | ✅ (all three methods + validation bypass covered; git-URL clones a real public repo — see Notes for the fixture choice and required VM package, and issue [#277](https://github.com/RXTX4816/cockpit-compose/issues/277) for a related intermittent flake) |
 | downed-stacks bulk actions (select-all + bulk Up, commit 85fe38d) | Bulk select/Up on downed stacks table | `e2e/downed-stacks-bulk.spec.ts` | ✅ |
 | 6.22 | Ports — clickable link, localhost-only vs all-interfaces tooltip | `e2e/ports.spec.ts` | ✅ (external-bind case; found a doc/behavior mismatch — see Notes) / 🚧 localhost/specific-bind cases |
 | adversarial | Malformed YAML, nonexistent scan directory, scan-depth bounds | `e2e/adversarial.spec.ts` | ✅ all 3 fixed and stable (3/3 × 2 full-file runs) — see Notes, these were real test bugs, not flakes |
@@ -163,6 +163,16 @@ scenarios).
     [#277](https://github.com/RXTX4816/cockpit-compose/issues/277); the spec works
     around it with a CSS-based click instead of `getByRole` and still verifies the
     real effect (file genuinely created/removed on disk via SSH, not just tab count).
+  - Create Stack's git-URL method needed a real `git` binary on the VM — none of the
+    scenarios installed one (`fetchComposeFromGit` shells out to `git clone`). Added
+    `git` unconditionally to `extra_packages()` in `scripts/test-vm.config.sh` for
+    every VM. The test clones `coollabsio/coolify` (a widely-used, actively-maintained
+    public repo with a real `docker-compose.yml` at its default branch's root) rather
+    than a fixture hosted in this project, to keep it pointed at a genuine external
+    git host. The same intermittent #277-class flake (stuck `aria-hidden` after
+    filling a modal's TextInput) was also observed on this file's pre-existing
+    manual-method and validation tests (not introduced by this change) — noted inline
+    in the spec.
 - **`arch-both` findings (Wave 2, first pass)**:
   - This VM's Docker only exposes a **Rootful** socket — no rootless Docker
     at all. `bulk-actions.spec.ts`'s four pre-existing Docker-default tests

--- a/e2e/create-stack.spec.ts
+++ b/e2e/create-stack.spec.ts
@@ -12,6 +12,13 @@ const DIR = '/home/test/testcompose';
 // no network/template dependency), confirms a real compose.yml + directory
 // were actually created (not just a UI toast), then deletes it again so the
 // test doesn't leave junk behind for other specs/runs.
+//
+// Intermittent flake, same class as issue #277 (yaml-editor.spec.ts): filling
+// the #csm-name/#csm-dir TextInputs occasionally leaves this modal's own
+// backdrop stuck at aria-hidden="true", so the "Create" button becomes
+// unreachable via getByRole even though it's still visibly present and
+// clickable. Reproduces roughly 1 in 3 runs on this VM; passes reliably when
+// re-run. Not fixed here — same root cause, tracked under #277.
 test('Create Stack (manual method) actually creates a compose file on disk', async ({ pluginPage: page }) => {
   await baseData(page);
 
@@ -71,6 +78,54 @@ test('Create Stack (template method) writes the real template YAML to disk, edit
   await expect(page.locator(`#dss-name-${TEMPLATE_NAME}`)).toHaveCount(0, { timeout: 15000 });
 });
 
+const GIT_NAME = 'e2e-create-git-test';
+// coollabsio/coolify: a widely-used, actively-maintained (60k+ stars) public
+// repo with a real docker-compose.yml at the root of its default branch —
+// used here (rather than a fixture hosted in this project) per explicit
+// steer to keep this test pointed at a genuine external repo, not something
+// we control ourselves.
+const GIT_URL = 'https://github.com/coollabsio/coolify';
+
+test('Create Stack (git URL method) clones a real repo and writes its actual compose file to disk', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  const modal = page.getByRole('dialog');
+  await modal.locator('#csm-name').fill(GIT_NAME);
+  await modal.locator('#csm-dir').fill(DIR);
+  await modal.getByRole('button', { name: 'From Git URL' }).click();
+  await modal.getByRole('button', { name: 'Next' }).click();
+
+  await modal.locator('#csm-git-url').fill(GIT_URL);
+  await modal.getByRole('button', { name: 'Fetch' }).click();
+
+  // Real effect: a genuine `git clone` ran against the real URL — the editor
+  // shows the actual cloned file's content, not a stub.
+  await expect(modal.locator('.cm-content')).toContainText('coolify', { timeout: 30000 });
+  await expect(modal.locator('.cm-content')).toContainText('postgres', { timeout: 5000 });
+
+  await modal.getByRole('button', { name: 'Create', exact: true }).click();
+  await expect(modal).not.toBeVisible({ timeout: 15000 });
+
+  // Real effect: rescan and confirm the file on disk actually contains the
+  // real cloned repo's content, not the editor's in-memory state.
+  await baseData(page);
+  const card = downedCard(page, GIT_NAME);
+  await expect(card).toBeVisible({ timeout: 15000 });
+  await card.getByRole('button', { name: 'Edit compose file' }).click({ force: true });
+  await expect(page.getByRole('dialog').locator('.cm-content')).toContainText('coolify', { timeout: 10000 });
+  await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click();
+
+  // Clean up.
+  await downedCard(page, GIT_NAME).getByRole('button', { name: 'Delete compose file' }).click();
+  await page.getByRole('button', { name: 'Delete', exact: true }).click();
+  await page.getByRole('button', { name: 'Yes, delete' }).click();
+  await expect(page.locator(`#dss-name-${GIT_NAME}`)).toHaveCount(0, { timeout: 15000 });
+});
+
+// Same #277-class flake as the manual-method test above can hit this one too
+// (it also fills #csm-name/#csm-dir) — see that test's comment.
 test('Create Stack validation: invalid YAML shows a real error count, and Create anyway bypasses it', async ({ pluginPage: page }) => {
   test.setTimeout(30_000);
   await baseData(page);

--- a/scripts/test-vm.config.sh
+++ b/scripts/test-vm.config.sh
@@ -22,6 +22,9 @@ extra_packages() {
   local vm="${2:-}"
   local scenario="${vm#*-}"
 
+  # git — needed by every scenario for Create Stack's "From Git URL" method
+  printf 'git\n'
+
   # Podman packages
   if [[ "$scenario" == "podman" || "$scenario" == "both" || "$scenario" == "podman-rootful" || "$scenario" == "full" ]]; then
     # passt is the Podman rootless network backend; not needed for Docker-only VMs


### PR DESCRIPTION
## Summary
- New test in `e2e/create-stack.spec.ts`: Create Stack via the "From Git URL" method actually clones a real public repo (`coollabsio/coolify`) and writes its real `docker-compose.yml` content to disk.
- Added `git` to every test VM's package list (`scripts/test-vm.config.sh`) — none had it installed, so `fetchComposeFromGit`'s `git clone` was failing with a generic "not-found" error regardless of repo choice. This was a real environment gap, not an app bug.
- Documented an intermittent flake (same class as #277 — filling a modal's TextInput occasionally leaves it stuck at `aria-hidden="true"`) found on this file's pre-existing manual-method and validation tests while investigating; not introduced by this change, noted inline and cross-referenced on #277.
- `docs/wiki/E2E-Test-Inventory.md` updated: 6.19 is now fully covered (manual/template/git-URL + validation bypass).

## Test plan
- [x] New git-URL test run 3x individually on `arch-podman`, stable.
- [x] Rebuilt `arch-podman` VM from scratch after the package-list change to confirm `git` installs correctly via cloud-init and the test passes against a genuinely fresh VM.
- [x] Full `create-stack.spec.ts` run: git-URL and template tests pass consistently; the pre-existing manual/validation tests hit the documented #277-class flake intermittently (~1/3 runs), unrelated to this change — confirmed by reproducing the same failure against the file's original (pre-my-changes) content.