### PR TITLE
test: cover Background Tasks log-view-through-panel

### DIFF
--- a/docs/wiki/E2E-Test-Inventory.md
+++ b/docs/wiki/E2E-Test-Inventory.md
@@ -77,7 +77,7 @@ scenarios).
 
 | Feature | Doc | Spec (planned) | Status |
 |---|---|---|---|
-| Background Tasks (queue, states, Stop/Remove, real container-state completion, runtime-switch cancellation) | [Background-Tasks.md](Background-Tasks) | `e2e/background-tasks.spec.ts` | ✅ (Pending→Running→Complete against real container state, Stop terminates the underlying process, Remove actually drops the task, runtime-switch cancellation race verified on `arch-both`) / 🚧 log-view-through-panel (cut, see spec header comment) |
+| Background Tasks (queue, states, Stop/Remove, real container-state completion, runtime-switch cancellation, log view) | [Background-Tasks.md](Background-Tasks) | `e2e/background-tasks.spec.ts` | ✅ (Pending→Running→Complete against real container state, Stop terminates the underlying process, Remove actually drops the task, runtime-switch cancellation race verified on `arch-both`, log-view-through-panel found a real z-index bug — see issue [#283](https://github.com/RXTX4816/cockpit-compose/issues/283) and Notes) |
 | Bulk Actions on running stacks (per-layout selection, select-all indeterminate, per-action confirm, runtime-switch clears selection) | [Bulk-Actions.md](Bulk-Actions) | `e2e/bulk-actions.spec.ts` | ✅ (Power User checkbox, Minimal card-click, Unix bracket-toggle, runtime-switch-clears-selection all covered) / 🚧 Pretty layout |
 | Process Viewer / Top (`docker compose top` equivalent) | [Process-Viewer.md](Process-Viewer) | `e2e/process-viewer.spec.ts` | ✅ |
 | Keyboard shortcuts (U/D/L/E/I) | [Stacks-Dashboard.md](Stacks-Dashboard#keyboard-shortcuts) | fold into `e2e/stacks.spec.ts` | ✅ |
@@ -294,11 +294,17 @@ scenarios).
     between the two modals, documented in `e2e/backup-restore.spec.ts` but not
     changed (no product decision requested for this pass).
   - Background Tasks: clicking a finished task to view its captured log
-    (`BackgroundTaskLogModal`) was manually verified to show real captured
-    output, but automating it reliably while the drawer stays open behind the
-    modal proved fragile (drawer intercepting clicks, ambiguous "Close"
-    targets) — cut from `e2e/background-tasks.spec.ts` this pass, see its
-    header comment.
+    (`BackgroundTaskLogModal`) — the earlier "fragile" flakiness was two real,
+    separate causes, both root-caused and fixed in a later pass: (1) a
+    leftover task from an earlier failed debugging run made the task-row
+    locator match a stale row instead of the fresh one under test, looking
+    like a real race but wasn't — fixed by clearing leftover `gotify` tasks
+    at the start of the test; (2) a genuine app bug — the still-open drawer's
+    own header physically overlaps and intercepts pointer events meant for
+    the log modal's footer "Close" button (both use the same z-index token),
+    so a real mouse click there silently does nothing for a real user too.
+    Filed as issue [#283](https://github.com/RXTX4816/cockpit-compose/issues/283);
+    the spec works around it with a programmatic click.
 - The "check config didn't break" principle from issue #227 has no literal
   Caddyfile-equivalent in this app (no reverse-proxy feature exists). It's applied
   here as: after YAML/env edits, assert file content really changed via a re-scan or

--- a/e2e/background-tasks.spec.ts
+++ b/e2e/background-tasks.spec.ts
@@ -34,14 +34,74 @@ test('Run in Background actually starts the stack, tracked through Pending → R
   await expect(stackRow(page, 'gotify')).toHaveAttribute('data-status', /running|partial/, { timeout: 10000 });
 });
 
-// Clicking a finished task shows its captured log (BackgroundTaskLogModal) —
-// verified manually to show real output from the run, not a placeholder.
-// Left out of the spec above: in this session, interacting with that modal
-// while the Background Tasks drawer stays open behind it was persistently
-// fragile (drawer header intercepting clicks, drawer/log-modal both being
-// dialogs with ambiguous "Close" targets) in ways that didn't reproduce
-// consistently enough to pin down within this pass — worth a focused
-// follow-up with devtools attached rather than more blind selector changes.
+// Clicking a finished task shows its captured log (BackgroundTaskLogModal).
+// Root-caused this session, two real, separate issues:
+// 1. A leftover task from an earlier failed run of this same spec made the
+//    task-row locator match a stale "Failed" row instead of the fresh one
+//    this test enqueues — looked exactly like a real race, wasn't one.
+//    Cleared explicitly below.
+// 2. A genuine app bug: the still-open drawer's own header physically
+//    overlaps and intercepts pointer events meant for the log modal's
+//    footer "Close" button (same z-index token on both) — filed as issue
+//    #283, worked around below with a programmatic click.
+test('Clicking a finished task shows its real captured log output', async ({ pluginPage: page }) => {
+  test.setTimeout(60_000);
+  await baseData(page);
+  await ensureDown(page, 'gotify');
+
+  // Background tasks persist until manually Removed — a leftover task from
+  // an earlier failed run of this same spec (e.g. while debugging) makes
+  // `taskRow` below match a *stale* row instead of the fresh one this test
+  // just enqueued, which looks exactly like a real race but isn't one.
+  // Clear any leftover gotify tasks first so this test only ever sees its
+  // own.
+  await page.getByRole('button', { name: 'Background tasks' }).click();
+  const panel = page.locator('.btd-panel');
+  for (const removeBtn of await panel.locator('li', { hasText: 'gotify' }).getByRole('button', { name: 'Remove' }).all()) {
+    await removeBtn.click().catch(() => {});
+  }
+  await page.getByRole('button', { name: 'Background tasks' }).click();
+
+  await downedCard(page, 'gotify').getByRole('button', { name: 'Up', exact: true }).click();
+  await page.getByRole('dialog', { name: /Confirm up.*gotify/ }).getByRole('button', { name: 'Up', exact: true }).click();
+  const progress = page.getByRole('dialog', { name: /^Up.*gotify/ });
+  await expect(progress).toBeVisible();
+  await progress.getByRole('button', { name: 'Run in Background' }).click();
+  await expect(progress).not.toBeVisible();
+
+  await page.getByRole('button', { name: 'Background tasks' }).click();
+  const taskRow = panel.locator('li', { hasText: 'gotify' });
+  await expect(taskRow.getByText('Complete', { exact: true })).toBeVisible({ timeout: 30000 });
+
+  // Click the row's title header specifically, not the whole `<li>` (which
+  // also contains the Remove button — clicking near it risked hitting that
+  // instead of the row's own onClick).
+  await taskRow.locator('.pf-v6-c-notification-drawer__list-item-header-title').click();
+  const logModal = page.getByRole('dialog', { name: /^Up.*gotify/ });
+  await expect(logModal).toBeVisible({ timeout: 10000 });
+
+  // Real effect: the modal shows genuine captured log output from the run
+  // (gotify's real startup log line), not an empty placeholder.
+  await expect(logModal.getByText(/gotify|listening|http/i).first()).toBeVisible({ timeout: 10000 });
+
+  // Real, separate bug found here (not #277's aria-hidden class): the
+  // background tasks drawer panel (.btd-panel) and the log modal share the
+  // same z-index token (--pf-t--global--z-index--xl), so the still-open
+  // drawer's own header physically overlaps and intercepts pointer events
+  // meant for the modal's footer "Close" button — Playwright's actionability
+  // check reports the drawer's <h1> as the element actually receiving clicks
+  // at that point. A real mouse click in this state would hit the wrong
+  // element too. Dispatching the click in-page instead of via simulated
+  // mouse coordinates exercises the same real onClick handler without
+  // depending on the (buggy) visual stacking order.
+  await page.locator('.btd-log-footer button').evaluate((el: HTMLElement) => el.click());
+  await expect(logModal).not.toBeVisible();
+
+  // Real effect: closing the log modal leaves the drawer itself intact and
+  // still showing the same completed task, not torn down along with it.
+  await expect(panel).toBeVisible();
+  await expect(taskRow.getByText('Complete', { exact: true })).toBeVisible();
+});
 
 test('Remove on a finished task actually drops it from the panel, not just hides it', async ({ pluginPage: page }) => {
   test.setTimeout(60_000);


### PR DESCRIPTION
## Summary
- Completes the previously-cut Background Tasks log-view test in `e2e/background-tasks.spec.ts`. Two real, separate root causes found:
  1. A leftover task from an earlier failed debugging run made the task-row locator match a stale row instead of the fresh one under test — looked exactly like a real race but wasn't. Fixed by clearing any leftover `gotify` tasks at the start of the test.
  2. A genuine app bug: the Background Tasks drawer's own header physically overlaps and intercepts pointer events meant for the log modal's footer "Close" button (both use the same z-index token) — a real mouse click there silently does nothing for a real user, not just test tooling. Filed as issue #283; the spec works around it with a programmatic click.
- `docs/wiki/E2E-Test-Inventory.md` updated.

## Test plan
- [x] New test run 3x individually on `arch-podman`, stable.
- [x] Full `background-tasks.spec.ts` passes (4 run, 1 correctly skipped — needs a dual-runtime VM).