### PR TITLE
feat: poll the container engine's REST API to cut high idle CPU usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "@patternfly/react-core": "^6.6.0",
         "@playwright/test": "^1.61.1",
-        "@rxtx4816/cockpit-plugin-base-react": "1.1.2",
+        "@rxtx4816/cockpit-plugin-base-react": "1.1.3",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.17",
@@ -1856,9 +1856,9 @@
       "license": "MIT"
     },
     "node_modules/@rxtx4816/cockpit-plugin-base-react": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rxtx4816/cockpit-plugin-base-react/-/cockpit-plugin-base-react-1.1.2.tgz",
-      "integrity": "sha512-HciSdAtWbLinrDlbng8IiJqn2q/cfZ2Zlv564j8R8n0mEZk/QkdpvFfWgpWJzgTLVuUUx/p/wZmI291elwswqg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rxtx4816/cockpit-plugin-base-react/-/cockpit-plugin-base-react-1.1.3.tgz",
+      "integrity": "sha512-zMHfOGkwsCtPL7iTzNbW8uZWPiR48+0+C6h0NFXuw+2k5MvTvJI169QW32TIjdWpQv3NvZoCmQCw+m0QRv5UAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@patternfly/react-core": "^6.6.0",
     "@playwright/test": "^1.61.1",
-    "@rxtx4816/cockpit-plugin-base-react": "1.1.2",
+    "@rxtx4816/cockpit-plugin-base-react": "1.1.3",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",

--- a/src/api/containers.test.ts
+++ b/src/api/containers.test.ts
@@ -1,14 +1,88 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { mockSpawn } from "../test/setup";
-import { mockProcess } from "../test/helpers";
+import { mockSpawn, mockHttp } from "../test/setup";
+import { mockProcess, mockHttpClient } from "../test/helpers";
 import { listContainers, getContainerStats } from "./containers";
 
-beforeEach(() => { mockSpawn.mockReset(); vi.resetModules(); });
+beforeEach(() => { mockSpawn.mockReset(); mockHttp.mockReset(); vi.resetModules(); });
+
+describe("listContainers [engine HTTP API]", () => {
+  it("uses the HTTP path when the engine socket is available, skipping the CLI entirely", async () => {
+    const cockpitMod = await import("./cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    mockHttp.mockReturnValue(mockHttpClient({
+      "/containers/json": JSON.stringify([
+        {
+          Id: "abc123",
+          Names: ["/myapp_web_1"],
+          Image: "nginx",
+          State: "running",
+          Status: "Up 5 minutes",
+          Ports: [{ IP: "0.0.0.0", PrivatePort: 80, PublicPort: 8080, Type: "tcp" }],
+          Labels: { "com.docker.compose.service": "web", "com.docker.compose.project": "myapp" },
+        },
+      ]),
+    }));
+
+    const { listContainers: lc } = await import("./containers");
+    let received = "";
+    const proc = lc("myapp");
+    proc.stream(d => { received += d; });
+    await proc;
+
+    const result = JSON.parse(received) as { ID: string; Name: string; Service: string; Ports: string }[];
+    expect(result).toHaveLength(1);
+    expect(result[0].ID).toBe("abc123");
+    expect(result[0].Name).toBe("myapp_web_1");
+    expect(result[0].Service).toBe("web");
+    expect(result[0].Ports).toBe("0.0.0.0:8080->80/tcp");
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("excludes one-off containers and omits unpublished ports over the HTTP path", async () => {
+    const cockpitMod = await import("./cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    mockHttp.mockReturnValue(mockHttpClient({
+      "/containers/json": JSON.stringify([
+        { Id: "c1", Image: "busybox", State: "exited", Status: "Exited", Labels: { "com.docker.compose.oneoff": "true", "com.docker.compose.project": "myapp" } },
+        { Id: "c2", Image: "nginx", State: "running", Status: "Up", Ports: [{ PrivatePort: 80, Type: "tcp" }], Labels: { "com.docker.compose.project": "myapp" } },
+      ]),
+    }));
+
+    const { listContainers: lc } = await import("./containers");
+    let received = "";
+    const proc = lc("myapp");
+    proc.stream(d => { received += d; });
+    await proc;
+
+    const result = JSON.parse(received) as { ID: string; Ports: string }[];
+    expect(result).toHaveLength(1);
+    expect(result[0].ID).toBe("c2");
+    expect(result[0].Ports).toBe("");
+  });
+
+  it("falls back to the CLI when the HTTP request fails", async () => {
+    const cockpitMod = await import("./cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    const failingClient = mockHttpClient();
+    vi.spyOn(failingClient, "get").mockRejectedValue(new Error("connection refused"));
+    mockHttp.mockReturnValue(failingClient);
+    mockSpawn.mockImplementation(() => mockProcess("[]"));
+
+    const { listContainers: lc } = await import("./containers");
+    const proc = lc("myapp");
+    await proc;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("listContainers [docker]", () => {
-  it("spawns compose ps --all --format json for the project", () => {
+  it("spawns compose ps --all --format json for the project", async () => {
     mockSpawn.mockReturnValue(mockProcess("[]"));
-    listContainers("myapp");
+    // listContainers() tries the engine HTTP API first (mocked to fail by default in this
+    // suite — see test/setup.ts), then falls back to the CLI spawn asserted on below; that
+    // fallback happens asynchronously, so the spawn call must be awaited before inspecting it.
+    await listContainers("myapp").catch(() => {});
     const args = mockSpawn.mock.calls[0][0] as string[];
     expect(args).toContain("-p");
     expect(args).toContain("myapp");
@@ -110,7 +184,11 @@ describe("listContainers [podman ports/oneoff edge cases]", () => {
     const cockpitMod = await import("./cockpit");
     cockpitMod.setRuntime("podman");
     vi.spyOn(cockpitMod, "composeIsLimitedBackend").mockReturnValue(true);
-    mockSpawn.mockReturnValue(mockProcess(JSON.stringify([
+    // Lazy: proc must be created at spawn-call time (not now), so its data-delivery microtask
+    // fires after proc.stream() is registered below — listContainers() now takes an extra
+    // async hop (the HTTP attempt) before reaching this CLI spawn, so an eagerly-created
+    // mockProcess would already have resolved with no stream callback registered yet.
+    mockSpawn.mockImplementation(() => mockProcess(JSON.stringify([
       { Id: "c1", Image: "busybox", State: "exited", Status: "Exited", Labels: { "com.docker.compose.oneoff": "True", "com.docker.compose.project": "myapp" } },
       { Id: "c2", Image: "nginx", State: "running", Status: "Up", Labels: { "com.docker.compose.project": "myapp" } },
     ])));
@@ -128,7 +206,7 @@ describe("listContainers [podman ports/oneoff edge cases]", () => {
     const cockpitMod = await import("./cockpit");
     cockpitMod.setRuntime("podman");
     vi.spyOn(cockpitMod, "composeIsLimitedBackend").mockReturnValue(true);
-    mockSpawn.mockReturnValue(mockProcess(JSON.stringify([
+    mockSpawn.mockImplementation(() => mockProcess(JSON.stringify([
       { Id: "c1", Image: "busybox", State: "running", Status: "Up", Ports: null, Labels: {} },
     ])));
     let received = "";
@@ -156,9 +234,9 @@ describe("superuser escalation (rootful Podman)", () => {
     vi.spyOn(cockpitMod, "socketSuperuser").mockReturnValue("try");
   });
 
-  it("listContainers passes superuser:'try' for the compose-backed path", () => {
+  it("listContainers passes superuser:'try' for the compose-backed path", async () => {
     mockSpawn.mockReturnValue(mockProcess("[]"));
-    listContainers("myapp");
+    await listContainers("myapp").catch(() => {});
     const opts = mockSpawn.mock.calls[0][1] as { superuser?: string };
     expect(opts.superuser).toBe("try");
   });

--- a/src/api/containers.ts
+++ b/src/api/containers.ts
@@ -1,4 +1,7 @@
 import { compose, cli, getIsPodman, dockerSpawnEnviron, composeIsLimitedBackend, socketSuperuser } from "./cockpit";
+import { engineHttpGetJson, drainProcess } from "./engineHttp";
+import { type EngineContainerJson, engineContainerName, enginePortsToString, isOneoffContainer } from "./engineJson";
+import { makeFakeProcess } from "./stacks/internal";
 
 interface PodmanPort {
   host_ip?: string;
@@ -67,12 +70,47 @@ function listContainersPodmanFallback(project: string): CockpitProcess {
   }) as unknown as CockpitProcess;
 }
 
-export function listContainers(project: string): CockpitProcess {
+// Pure read, so it's tried over the engine's REST API first — skips the per-poll cost of
+// spawning a whole new process (and, for compose specifically, a Python interpreter) just to
+// list containers that already exist. Falls back to the exact CLI behavior below on any
+// failure (old engine version, socket unavailable, unexpected response), so this can never be
+// less reliable than the CLI path — only sometimes faster.
+async function listContainersHttp(project: string): Promise<string> {
+  const items = await engineHttpGetJson<EngineContainerJson[]>("/containers/json", {
+    all: "true",
+    filters: JSON.stringify({ label: [`com.docker.compose.project=${project}`] }),
+  });
+  // Exclude one-off run containers (compose run --rm); they carry
+  // com.docker.compose.oneoff=True and would inflate service replica counts.
+  const filtered = items.filter(c => !isOneoffContainer(c));
+  return JSON.stringify(filtered.map(c => ({
+    ID: c.Id,
+    Name: engineContainerName(c),
+    Image: c.Image,
+    State: c.State,
+    Status: c.Status,
+    Health: "",
+    Ports: enginePortsToString(c.Ports),
+    Service: c.Labels?.["com.docker.compose.service"] ?? "",
+  })));
+}
+
+function listContainersCli(project: string): CockpitProcess {
   if (composeIsLimitedBackend()) return listContainersPodmanFallback(project);
   return cockpit.spawn(
     compose("-p", project, "ps", "--all", "--format", "json"),
     { superuser: socketSuperuser(), err: "message", ...dockerSpawnEnviron() },
   );
+}
+
+export function listContainers(project: string): CockpitProcess {
+  return makeFakeProcess(async () => {
+    try {
+      return await listContainersHttp(project);
+    } catch {
+      return await drainProcess(listContainersCli(project));
+    }
+  });
 }
 
 export function getContainerStats(containerIds: string[]): CockpitProcess {

--- a/src/api/engineHttp.test.ts
+++ b/src/api/engineHttp.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockHttp } from "../test/setup";
+import { mockHttpClient } from "../test/helpers";
+
+vi.mock("./cockpit", () => ({
+  getDockerSocketPath: vi.fn(),
+  getPodmanSocketPath: vi.fn(),
+  getIsPodman: vi.fn(() => false),
+  socketSuperuser: vi.fn(() => undefined),
+}));
+
+import { getDockerSocketPath, getPodmanSocketPath, getIsPodman } from "./cockpit";
+import { engineHttpGetJson, _resetEngineHttpAvailabilityForTests } from "./engineHttp";
+
+const mockGetDockerSocketPath = vi.mocked(getDockerSocketPath);
+const mockGetPodmanSocketPath = vi.mocked(getPodmanSocketPath);
+const mockGetIsPodman = vi.mocked(getIsPodman);
+
+beforeEach(() => {
+  mockHttp.mockReset();
+  mockGetDockerSocketPath.mockReset();
+  mockGetPodmanSocketPath.mockReset();
+  mockGetIsPodman.mockReset().mockReturnValue(false);
+  _resetEngineHttpAvailabilityForTests();
+});
+
+describe("engineHttpGetJson", () => {
+  it("strips the unix:// prefix and GETs the given path over the docker socket", async () => {
+    mockGetDockerSocketPath.mockReturnValue("unix:///var/run/docker.sock");
+    mockHttp.mockReturnValue(mockHttpClient({ "/containers/json": JSON.stringify([{ Id: "abc" }]) }));
+
+    const result = await engineHttpGetJson("/containers/json");
+
+    expect(result).toEqual([{ Id: "abc" }]);
+    expect(mockHttp).toHaveBeenCalledWith("/var/run/docker.sock", expect.objectContaining({}));
+  });
+
+  it("uses the podman socket when running in podman mode", async () => {
+    mockGetIsPodman.mockReturnValue(true);
+    mockGetPodmanSocketPath.mockReturnValue("unix:///run/user/1000/podman/podman.sock");
+    mockHttp.mockReturnValue(mockHttpClient({ "/containers/json": "[]" }));
+
+    await engineHttpGetJson("/containers/json");
+
+    expect(mockHttp).toHaveBeenCalledWith("/run/user/1000/podman/podman.sock", expect.objectContaining({}));
+    expect(mockGetDockerSocketPath).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no socket has been detected", async () => {
+    mockGetDockerSocketPath.mockReturnValue(undefined);
+    await expect(engineHttpGetJson("/containers/json")).rejects.toThrow();
+    expect(mockHttp).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the HTTP request itself fails", async () => {
+    mockGetDockerSocketPath.mockReturnValue("unix:///var/run/docker.sock");
+    const client = mockHttpClient();
+    vi.spyOn(client, "get").mockRejectedValue(new Error("connection refused"));
+    mockHttp.mockReturnValue(client);
+
+    await expect(engineHttpGetJson("/containers/json")).rejects.toThrow("connection refused");
+  });
+
+  it("skips retrying the HTTP path for a while after a failure", async () => {
+    mockGetDockerSocketPath.mockReturnValue("unix:///var/run/docker.sock");
+    const client = mockHttpClient();
+    vi.spyOn(client, "get").mockRejectedValue(new Error("connection refused"));
+    mockHttp.mockReturnValue(client);
+
+    await expect(engineHttpGetJson("/containers/json")).rejects.toThrow();
+    expect(mockHttp).toHaveBeenCalledTimes(1);
+
+    // A second call shortly after should short-circuit without touching cockpit.http again —
+    // avoids paying a failed-connection cost on every single poll while the socket is down.
+    await expect(engineHttpGetJson("/containers/json")).rejects.toThrow();
+    expect(mockHttp).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the HTTP path again once a request succeeds", async () => {
+    mockGetDockerSocketPath.mockReturnValue("unix:///var/run/docker.sock");
+    const failingClient = mockHttpClient();
+    vi.spyOn(failingClient, "get").mockRejectedValue(new Error("connection refused"));
+    mockHttp.mockReturnValueOnce(failingClient);
+    await expect(engineHttpGetJson("/containers/json")).rejects.toThrow();
+
+    // Bypass the cooldown directly (rather than waiting out the real 60s) to confirm a
+    // success clears the failure state for subsequent calls.
+    _resetEngineHttpAvailabilityForTests();
+    mockHttp.mockReturnValueOnce(mockHttpClient({ "/containers/json": "[]" }));
+    await expect(engineHttpGetJson("/containers/json")).resolves.toEqual([]);
+  });
+});

--- a/src/api/engineHttp.ts
+++ b/src/api/engineHttp.ts
@@ -1,0 +1,52 @@
+import { getDockerSocketPath, getPodmanSocketPath, getIsPodman, socketSuperuser } from "./cockpit";
+
+// Once a socket request fails (old engine version, path unreachable, unexpected response),
+// skip retrying the HTTP path for a while rather than paying a failed-connection cost on
+// every single poll — the CLI fallback handles those ticks in the meantime. Cleared as soon
+// as a request succeeds again.
+const UNAVAILABLE_RETRY_MS = 60_000;
+let unavailableSince: number | undefined;
+
+function currentSocketPath(): string | undefined {
+  const raw = getIsPodman() ? getPodmanSocketPath() : getDockerSocketPath();
+  // getDockerSocketPath()/getPodmanSocketPath() return "unix:///path/to.sock" (matching the
+  // DOCKER_HOST format used for CLI env vars) — cockpit.http() wants the bare filesystem path.
+  return raw?.replace(/^unix:\/\//, "");
+}
+
+// GETs `path` from the current container engine's REST API over its Unix socket and parses
+// the response as JSON. Throws (and briefly disables further HTTP attempts) on any failure —
+// callers are expected to catch this and fall back to the equivalent CLI command.
+export async function engineHttpGetJson<T>(path: string, params?: Record<string, string>): Promise<T> {
+  if (unavailableSince !== undefined && Date.now() - unavailableSince < UNAVAILABLE_RETRY_MS) {
+    throw new Error("engine socket recently failed, skipping HTTP path");
+  }
+  const socketPath = currentSocketPath();
+  if (!socketPath) throw new Error("no engine socket detected");
+
+  const http = cockpit.http(socketPath, { superuser: socketSuperuser() });
+  try {
+    const raw = await http.get(path, params);
+    unavailableSince = undefined;
+    return JSON.parse(raw) as T;
+  } catch (e) {
+    unavailableSince = Date.now();
+    throw e;
+  } finally {
+    http.close();
+  }
+}
+
+// Test-only: resets the failure cooldown so each test starts from a clean slate.
+export function _resetEngineHttpAvailabilityForTests(): void {
+  unavailableSince = undefined;
+}
+
+// Collects a CockpitProcess's streamed output into a single string once it completes — used
+// to fall back to an existing CLI-based implementation from inside an async HTTP-first path.
+export async function drainProcess(proc: CockpitProcess): Promise<string> {
+  let raw = "";
+  proc.stream(d => { raw += d; });
+  await proc;
+  return raw;
+}

--- a/src/api/engineJson.ts
+++ b/src/api/engineJson.ts
@@ -1,0 +1,40 @@
+// Shapes and helpers for the raw JSON returned by the Docker/Podman Engine REST API
+// (GET /containers/json), as opposed to the CLI's own `--format json` output — the two use
+// different field names and structure for the same data (e.g. `Id` vs `ID`, ports as
+// structured objects vs a pre-formatted string), so responses from the HTTP path are
+// converted to match what the existing CLI-based code already produces.
+
+export interface EngineContainerPort {
+  IP?: string;
+  PrivatePort: number;
+  PublicPort?: number;
+  Type: string;
+}
+
+export interface EngineContainerJson {
+  Id: string;
+  Names?: string[];
+  Image: string;
+  State: string;
+  Status: string;
+  Ports?: EngineContainerPort[];
+  Labels?: Record<string, string>;
+}
+
+export function engineContainerName(c: EngineContainerJson): string {
+  return (c.Names?.[0] ?? "").replace(/^\//, "");
+}
+
+// Matches the CLI's Ports column: only published (host-mapped) ports are shown, not every
+// port the image merely EXPOSEs.
+export function enginePortsToString(ports: EngineContainerPort[] | undefined): string {
+  if (!ports || ports.length === 0) return "";
+  return ports
+    .filter(p => p.PublicPort !== undefined)
+    .map(p => `${p.IP || "0.0.0.0"}:${p.PublicPort}->${p.PrivatePort}/${p.Type}`)
+    .join(", ");
+}
+
+export function isOneoffContainer(c: EngineContainerJson): boolean {
+  return c.Labels?.["com.docker.compose.oneoff"]?.toLowerCase() === "true";
+}

--- a/src/api/stacks/query.test.ts
+++ b/src/api/stacks/query.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { mockSpawn } from "../../test/setup";
-import { mockProcess } from "../../test/helpers";
+import { mockSpawn, mockHttp } from "../../test/setup";
+import { mockProcess, mockHttpClient } from "../../test/helpers";
 import { setRuntime, detectComposeCommand } from "../cockpit";
 import {
   groupPodmanContainers, listStacks, readRunningServiceNames, streamLogs, streamEvents,
@@ -13,6 +13,7 @@ import {
 beforeEach(() => {
   mockSpawn.mockReset();
   mockSpawn.mockReturnValue(mockProcess(""));
+  mockHttp.mockReset();
   setRuntime("docker");
 });
 
@@ -31,16 +32,51 @@ async function forcePodmanLimitedBackend(): Promise<void> {
   vi.stubGlobal("cockpit", { spawn: mockSpawn });
 }
 
+describe("listStacks [engine HTTP API]", () => {
+  it("uses the HTTP path when the engine socket is available, skipping the CLI entirely", async () => {
+    const cockpitMod = await import("../cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    mockHttp.mockReturnValue(mockHttpClient({
+      "/containers/json": JSON.stringify([
+        { State: "running", Labels: { "com.docker.compose.project": "myapp", "com.docker.compose.project.config_files": "/myapp/compose.yml" } },
+        { State: "exited", Labels: { "com.docker.compose.project": "myapp", "com.docker.compose.project.config_files": "/myapp/compose.yml" } },
+      ]),
+    }));
+
+    const out = await listStacks();
+    expect(JSON.parse(out as unknown as string)).toEqual([
+      { Name: "myapp", Status: "exited(1), running(1)", ConfigFiles: "/myapp/compose.yml" },
+    ]);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the CLI when the HTTP request fails", async () => {
+    const cockpitMod = await import("../cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    const failingClient = mockHttpClient();
+    vi.spyOn(failingClient, "get").mockRejectedValue(new Error("connection refused"));
+    mockHttp.mockReturnValue(failingClient);
+
+    await listStacks().catch(() => {});
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("listStacks", () => {
-  it("docker mode: runs compose ls", () => {
-    listStacks();
+  it("docker mode: runs compose ls", async () => {
+    // listStacks() tries the engine HTTP API first (mocked to fail by default — see
+    // test/setup.ts), then falls back to the CLI spawn asserted on below, asynchronously.
+    await listStacks().catch(() => {});
     const args = mockSpawn.mock.calls[0][0] as string[];
     expect(args).toEqual(["docker", "compose", "ls", "--all", "--format", "json"]);
   });
 
   it("podman mode: falls back to podman ps + groupPodmanContainers, resolving to grouped JSON", async () => {
     setRuntime("podman");
-    mockSpawn.mockReturnValue(mockProcess(JSON.stringify([
+    // Lazy: listStacks() tries the engine HTTP API first (an extra async hop before this CLI
+    // spawn), so an eagerly-created mockProcess would resolve before proc.stream() is
+    // registered — see the same fix in containers.test.ts.
+    mockSpawn.mockImplementation(() => mockProcess(JSON.stringify([
       { State: "running", Labels: { "com.docker.compose.project": "myapp", "com.docker.compose.project.config_files": "/myapp/compose.yml" } },
     ])));
     const out = await listStacks();

--- a/src/api/stacks/query.ts
+++ b/src/api/stacks/query.ts
@@ -1,5 +1,6 @@
 import { compose, cli, getIsPodman, dockerSpawnEnviron, composeIsLimitedBackend, socketSuperuser } from "../cockpit";
 import { fileFlags, makeFakeProcess, type PodmanPsContainer, type PodmanPsForImages, type PodmanImageInspect, type PodmanVolumeJson } from "./internal";
+import { engineHttpGetJson, drainProcess } from "../engineHttp";
 
 // podman-compose (Python) is known to record whatever path was passed on the CLI in the
 // com.docker.compose.project.config_files label, without resolving it to an absolute path
@@ -77,10 +78,33 @@ function listPodmanStacks(): CockpitProcess {
   }) as unknown as CockpitProcess;
 }
 
-export function listStacks(): CockpitProcess {
+// Pure read, so it's tried over the engine's REST API first — same rationale as
+// listContainers() in ../containers.ts. groupPodmanContainers() only needs each container's
+// State and Labels, which the raw Engine API JSON already provides in matching shape, so the
+// same grouping logic already proven for the podman CLI fallback works unchanged for both
+// engines here. Falls back to the exact CLI behavior below on any failure.
+async function listStacksHttp(): Promise<string> {
+  const containers = await engineHttpGetJson<PodmanPsContainer[]>("/containers/json", {
+    all: "true",
+    filters: JSON.stringify({ label: ["com.docker.compose.project"] }),
+  });
+  return JSON.stringify(groupPodmanContainers(containers));
+}
+
+function listStacksCli(): CockpitProcess {
   if (getIsPodman()) return listPodmanStacks();
   return cockpit.spawn(compose("ls", "--all", "--format", "json"), {
     superuser: socketSuperuser(), err: "message", ...dockerSpawnEnviron(),
+  });
+}
+
+export function listStacks(): CockpitProcess {
+  return makeFakeProcess(async () => {
+    try {
+      return await listStacksHttp();
+    } catch {
+      return await drainProcess(listStacksCli());
+    }
   });
 }
 

--- a/src/components/StackInfoModal.test.tsx
+++ b/src/components/StackInfoModal.test.tsx
@@ -51,35 +51,56 @@ const volumes = JSON.stringify([
   { Name: "myapp_data", Driver: "local", Mountpoint: "/var/lib/docker/volumes/myapp_data/_data" },
 ]);
 
-function mockSpawnSequence(...responses: ReturnType<typeof mockProcess>[]) {
-  let i = 0;
-  mockSpawn.mockImplementation(() => responses[Math.min(i++, responses.length - 1)]);
+// Takes lazy factories, not pre-built processes: listContainers()/etc. now try the engine
+// HTTP API first (an extra async hop before reaching these CLI spawns), so a process built
+// eagerly (at the time this is called, before render()) would have its data-delivery
+// microtask fire before .stream() is ever registered by the real caller — see the identical
+// fix applied in containers.test.ts.
+//
+// Routed by inspecting the actual command being spawned, not by call arrival order: the
+// modal fires its containers/images/volumes/networks effects in that declaration order, but
+// listContainers()'s extra async hop above means its underlying CLI spawn can now land
+// *after* the still-synchronous images/volumes calls from later effects — arrival order no
+// longer matches the positional order these factories are written in.
+function mockSpawnSequence(...factories: (() => ReturnType<typeof mockProcess>)[]) {
+  let networkIdx = 3;
+  mockSpawn.mockImplementation((args: string[]) => {
+    if (args.includes("images")) return (factories[1] ?? (() => mockProcess("")))();
+    if (args.includes("volumes")) return (factories[2] ?? (() => mockProcess("")))();
+    if (args.includes("ps") && args.includes("--all")) return (factories[0] ?? (() => mockProcess("")))();
+    // Both listProjectNetworks ("network ls") and listNetworkConnectedProjects
+    // ("ps --filter network=...") share the remaining positional slots, clamped to the last
+    // one once exhausted — matching how the original position-based sequence behaved.
+    const f = factories[Math.min(networkIdx, factories.length - 1)] ?? (() => mockProcess(""));
+    networkIdx++;
+    return f();
+  });
 }
 
 describe("StackInfoModal", () => {
   it("renders modal title with stack name", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     expect(screen.getByText(/myapp — info/i)).toBeInTheDocument();
     await act(async () => {});
   });
 
   it("shows spinners while loading", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     expect(screen.getAllByRole("progressbar").length).toBeGreaterThan(0);
     await act(async () => {});
   });
 
   it("shows config file path", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     expect(screen.getByText("/path/docker-compose.yml")).toBeInTheDocument();
     await act(async () => {});
   });
 
   it("renders container info after loading", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
     expect(screen.getByText("web")).toBeInTheDocument();
@@ -88,32 +109,32 @@ describe("StackInfoModal", () => {
   });
 
   it("shows truncated container ID (12 chars)", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
     expect(screen.getByText("abc123def456")).toBeInTheDocument();
   });
 
   it("renders port label for mapped ports", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText("0.0.0.0:8080 → 80/tcp")).toBeInTheDocument());
   });
 
   it("shows empty state when no containers returned", async () => {
-    mockSpawnSequence(mockProcess("[]"), mockProcess("[]"), mockProcess("[]"), mockProcess(""));
+    mockSpawnSequence(() => mockProcess("[]"), () => mockProcess("[]"), () => mockProcess("[]"), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/No containers found/i)).toBeInTheDocument());
   });
 
   it("shows error alert on container fetch failure", async () => {
-    mockSpawnSequence(mockProcess("", "permission denied"), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess("", "permission denied"), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/Could not load container info/i)).toBeInTheDocument());
   });
 
   it("renders images table after loading", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
     expect(screen.getByText("nginx")).toBeInTheDocument();
@@ -121,13 +142,13 @@ describe("StackInfoModal", () => {
   });
 
   it("shows images error alert on failure", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess("", "images failed"), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess("", "images failed"), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/Could not load images/i)).toBeInTheDocument());
   });
 
   it("renders volumes table after loading", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
     expect(screen.getByText("myapp_data")).toBeInTheDocument();
@@ -135,13 +156,13 @@ describe("StackInfoModal", () => {
   });
 
   it("shows unavailable notice when docker compose volumes is not supported", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess("", "unknown command"), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess("", "unknown command"), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/Not available on this Docker Compose version/i)).toBeInTheDocument());
   });
 
   it("renders networks section with no networks found", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
     expect(screen.getByText(/No networks found/i)).toBeInTheDocument();
@@ -149,11 +170,11 @@ describe("StackInfoModal", () => {
 
   it("renders network name in networks table", async () => {
     mockSpawnSequence(
-      mockProcess(containers),
-      mockProcess(images),
-      mockProcess(volumes),
-      mockProcess("myapp_default\n"),
-      mockProcess(""),
+      () => mockProcess(containers),
+      () => mockProcess(images),
+      () => mockProcess(volumes),
+      () => mockProcess("myapp_default\n"),
+      () => mockProcess(""),
     );
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
@@ -162,11 +183,11 @@ describe("StackInfoModal", () => {
 
   it("shows other project name when network is shared", async () => {
     mockSpawnSequence(
-      mockProcess(containers),
-      mockProcess(images),
-      mockProcess(volumes),
-      mockProcess("myapp_default\n"),
-      mockProcess("otherapp\n"),
+      () => mockProcess(containers),
+      () => mockProcess(images),
+      () => mockProcess(volumes),
+      () => mockProcess("myapp_default\n"),
+      () => mockProcess("otherapp\n"),
     );
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
@@ -174,13 +195,13 @@ describe("StackInfoModal", () => {
   });
 
   it("shows volume error alert for non-unknown-command failures", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess("", "permission denied"), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess("", "permission denied"), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/Could not load volumes/i)).toBeInTheDocument());
   });
 
   it("shows network error alert when network fetch fails", async () => {
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess("", "network error"));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess("", "network error"));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/Could not load networks/i)).toBeInTheDocument());
   });
@@ -204,7 +225,7 @@ services:
     profiles: [debug]
 `;
     mockReadComposeFile.mockImplementation(() => mockProcess(composeWithProfiles));
-    mockSpawnSequence(mockProcess(containerWithService), mockProcess("[]"), mockProcess("[]"), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containerWithService), () => mockProcess("[]"), () => mockProcess("[]"), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText("Profiles")).toBeInTheDocument());
     expect(screen.getAllByText("debug").length).toBeGreaterThan(0);
@@ -215,7 +236,7 @@ services:
       new Promise<string>((_, reject) => queueMicrotask(() => reject("img string error"))),
       { stream: vi.fn().mockReturnThis(), close: vi.fn(), input: vi.fn() },
     ) as CockpitProcess;
-    mockSpawnSequence(mockProcess(containers), nonErrorProcess, mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => nonErrorProcess, () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/Could not load images/i)).toBeInTheDocument());
     expect(screen.getByText("img string error")).toBeInTheDocument();
@@ -223,7 +244,7 @@ services:
 
   it("renders volume rows with fallback dashes for missing fields", async () => {
     const emptyVolume = JSON.stringify([{ Name: "", Driver: "", Mountpoint: "" }]);
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(emptyVolume), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(emptyVolume), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
     expect(screen.getAllByText("—").length).toBeGreaterThan(0);
@@ -232,7 +253,7 @@ services:
   it("copy button invokes clipboard.writeText and shows copied state", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, writable: true, configurable: true });
-    mockSpawnSequence(mockProcess(containers), mockProcess(images), mockProcess(volumes), mockProcess(""));
+    mockSpawnSequence(() => mockProcess(containers), () => mockProcess(images), () => mockProcess(volumes), () => mockProcess(""));
     render(<StackInfoModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
     const copyBtn = screen.getAllByRole("button").find(b => b.getAttribute("aria-label")?.toLowerCase().includes("copy container"));

--- a/src/components/StacksView/MinimalCard.test.tsx
+++ b/src/components/StacksView/MinimalCard.test.tsx
@@ -25,9 +25,11 @@ vi.mock("../LogsModal", () => ({
 import { useStackActions } from "../../hooks/useStackActions";
 import { useServiceActions } from "../../hooks/useServiceActions";
 import { useStackContainers } from "../../hooks/useStackContainers";
+import { useAutoRefresh } from "../../hooks/useAutoRefresh";
 const mockUseStackActions = vi.mocked(useStackActions);
 const mockUseServiceActions = vi.mocked(useServiceActions);
 const mockUseStackContainers = vi.mocked(useStackContainers);
+const mockUseAutoRefresh = vi.mocked(useAutoRefresh);
 
 const stack: ComposeStack = { Name: "myapp", Status: "running(2)", ConfigFiles: "/myapp/compose.yml" };
 const stoppedStack: ComposeStack = { Name: "myapp", Status: "exit(0)", ConfigFiles: "/myapp/compose.yml" };
@@ -55,6 +57,7 @@ const defaultProps = {
   onBackup: vi.fn(),
   onScale: vi.fn(),
   onActingChange: vi.fn(),
+  onRefresh: vi.fn(),
 };
 
 beforeEach(() => {
@@ -306,6 +309,30 @@ describe("MinimalCard", () => {
       fireEvent.click(screen.getByText(/^restart$/i));
       fireEvent.click(screen.getByText(/^pause$/i));
       expect(doAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("container polling pause (#289)", () => {
+    it("does not pause polling by default (no other action in flight)", () => {
+      render(<MinimalCard {...defaultProps} />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, false);
+    });
+
+    it("pauses polling while another action is in flight elsewhere on the page", () => {
+      render(<MinimalCard {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, true);
+    });
+
+    it("does not pause polling for this row's own stack action, even while globalActing", () => {
+      mockUseStackActions.mockReturnValue({ acting: true, actionError: null, doAction: vi.fn() });
+      render(<MinimalCard {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 500, false);
+    });
+
+    it("does not pause polling for this row's own service action, even while globalActing", () => {
+      mockUseServiceActions.mockReturnValue({ actingService: "web", doServiceAction: vi.fn() });
+      render(<MinimalCard {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, false);
     });
   });
 });

--- a/src/components/StacksView/MinimalCard.tsx
+++ b/src/components/StacksView/MinimalCard.tsx
@@ -67,8 +67,10 @@ interface MinimalCardProps {
   onBackup: () => void;
   onScale: () => void;
   onActingChange: (delta: 1 | -1) => void;
+  onRefresh: () => void;
   isSelected?: boolean;
   onToggleSelect?: () => void;
+  globalActing?: boolean;
 }
 
 const STATUS_VARS: Record<string, { bg: string; border: string }> = {
@@ -81,8 +83,8 @@ const STATUS_VARS: Record<string, { bg: string; border: string }> = {
 
 export function MinimalCard({
   stack, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull,
-  onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange,
-  isSelected = false, onToggleSelect,
+  onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange, onRefresh,
+  isSelected = false, onToggleSelect, globalActing = false,
 }: MinimalCardProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -106,10 +108,19 @@ export function MinimalCard({
   const afterAction = useCallback(async () => {
     clearContainers();
     await loadContainers();
-  }, [clearContainers, loadContainers]);
+    // Refresh the page-level stack list immediately rather than waiting for its own poll
+    // (which can now be backed off several seconds on constrained hardware) — otherwise a
+    // finished action looks stuck until the next scheduled tick happens to land.
+    onRefresh();
+  }, [clearContainers, loadContainers, onRefresh]);
+
+  const afterServiceAction = useCallback(async () => {
+    await loadContainers();
+    onRefresh();
+  }, [loadContainers, onRefresh]);
 
   useEffect(() => { void loadContainers(); }, [loadContainers]);
-  useAutoRefresh(loadContainers, acting ? 500 : 3000, false);
+  useAutoRefresh(loadContainers, acting ? 500 : 3000, globalActing && !acting && !actingService);
 
   const clearOpenTimer = () => {
     if (openTimerRef.current !== null) {
@@ -304,9 +315,9 @@ export function MinimalCard({
                 containers={containers}
                 actions={{
                   actingService,
-                  onStart: s => { void doServiceAction("start", s, loadContainers); },
-                  onStop: s => { void doServiceAction("stop", s, loadContainers); },
-                  onRestart: s => { void doServiceAction("restart", s, loadContainers); },
+                  onStart: s => { void doServiceAction("start", s, afterServiceAction); },
+                  onStop: s => { void doServiceAction("stop", s, afterServiceAction); },
+                  onRestart: s => { void doServiceAction("restart", s, afterServiceAction); },
                   onLogs: s => setLogsService(s),
                 }}
               />

--- a/src/components/StacksView/PrettyCard.test.tsx
+++ b/src/components/StacksView/PrettyCard.test.tsx
@@ -25,9 +25,11 @@ vi.mock("./StatsCell", () => ({
 import { useStackActions } from "../../hooks/useStackActions";
 import { useStackContainers } from "../../hooks/useStackContainers";
 import { useContainerStats } from "../../hooks/useContainerStats";
+import { useAutoRefresh } from "../../hooks/useAutoRefresh";
 const mockUseStackActions = vi.mocked(useStackActions);
 const mockUseStackContainers = vi.mocked(useStackContainers);
 const mockUseContainerStats = vi.mocked(useContainerStats);
+const mockUseAutoRefresh = vi.mocked(useAutoRefresh);
 
 async function click(element: Element) {
   await act(async () => {
@@ -57,6 +59,7 @@ const defaultProps = {
   onBackup: vi.fn(),
   onScale: vi.fn(),
   onActingChange: vi.fn(),
+  onRefresh: vi.fn(),
 };
 
 beforeEach(() => {
@@ -326,6 +329,24 @@ describe("PrettyCard", () => {
       render(<PrettyCard {...defaultProps} onToggleSelect={onToggleSelect} />);
       fireEvent.click(screen.getByRole("button", { name: /expand/i }));
       expect(onToggleSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("container polling pause (#289)", () => {
+    it("does not pause polling by default (no other action in flight)", () => {
+      render(<PrettyCard {...defaultProps} />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, false);
+    });
+
+    it("pauses polling while another action is in flight elsewhere on the page", () => {
+      render(<PrettyCard {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, true);
+    });
+
+    it("does not pause polling for this row's own stack action, even while globalActing", () => {
+      mockUseStackActions.mockReturnValue({ acting: true, actionError: null, doAction: vi.fn() });
+      render(<PrettyCard {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 500, false);
     });
   });
 });

--- a/src/components/StacksView/PrettyCard.tsx
+++ b/src/components/StacksView/PrettyCard.tsx
@@ -66,8 +66,10 @@ interface PrettyCardProps {
   onBackup: () => void;
   onScale: () => void;
   onActingChange: (delta: 1 | -1) => void;
+  onRefresh: () => void;
   isSelected?: boolean;
   onToggleSelect?: () => void;
+  globalActing?: boolean;
 }
 
 const STATUS_BORDER: Record<string, string> = {
@@ -88,8 +90,8 @@ const STATUS_GLOW: Record<string, string> = {
 
 export function PrettyCard({
   stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull,
-  onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange,
-  isSelected = false, onToggleSelect,
+  onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange, onRefresh,
+  isSelected = false, onToggleSelect, globalActing = false,
 }: PrettyCardProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -113,7 +115,16 @@ export function PrettyCard({
   const afterAction = useCallback(async () => {
     clearContainers();
     await loadContainers();
-  }, [clearContainers, loadContainers]);
+    // Refresh the page-level stack list immediately rather than waiting for its own poll
+    // (which can now be backed off several seconds on constrained hardware) — otherwise a
+    // finished action looks stuck until the next scheduled tick happens to land.
+    onRefresh();
+  }, [clearContainers, loadContainers, onRefresh]);
+
+  const afterServiceAction = useCallback(async () => {
+    await loadContainers();
+    onRefresh();
+  }, [loadContainers, onRefresh]);
 
   const handleToggle = () => {
     onToggle();
@@ -129,7 +140,7 @@ export function PrettyCard({
     : undefined;
 
   useEffect(() => { void loadContainers(); }, [loadContainers]);
-  useAutoRefresh(loadContainers, acting ? 500 : 3000, false);
+  useAutoRefresh(loadContainers, acting ? 500 : 3000, globalActing && !acting && !actingService);
 
   const isRunning = status === "running" || status === "partial";
   const cpuPct = stats?.cpu ?? 0;
@@ -336,7 +347,7 @@ export function PrettyCard({
                                 <button
                                   className="pc-svc-btn"
                                   aria-label={t("service_actions.stop")}
-                                  onClick={() => void doServiceAction("stop", svc, loadContainers)}
+                                  onClick={() => void doServiceAction("stop", svc, afterServiceAction)}
                                   disabled={acting}
                                 >
                                   <BanIcon />
@@ -347,7 +358,7 @@ export function PrettyCard({
                                 <button
                                   className="pc-svc-btn"
                                   aria-label={t("service_actions.start")}
-                                  onClick={() => void doServiceAction("start", svc, loadContainers)}
+                                  onClick={() => void doServiceAction("start", svc, afterServiceAction)}
                                   disabled={acting}
                                 >
                                   <PlayIcon />
@@ -358,7 +369,7 @@ export function PrettyCard({
                               <button
                                 className="pc-svc-btn"
                                 aria-label={t("service_actions.restart")}
-                                onClick={() => void doServiceAction("restart", svc, loadContainers)}
+                                onClick={() => void doServiceAction("restart", svc, afterServiceAction)}
                                 disabled={acting}
                               >
                                 <RedoAltIcon />

--- a/src/components/StacksView/StackRow.test.tsx
+++ b/src/components/StacksView/StackRow.test.tsx
@@ -6,17 +6,27 @@ import type { ComposeStack } from "../../api";
 vi.mock("../../hooks/useStackActions", () => ({
   useStackActions: vi.fn(),
 }));
+vi.mock("../../hooks/useServiceActions", () => ({
+  useServiceActions: vi.fn(),
+}));
 vi.mock("../../hooks/useStackContainers", () => ({
   useStackContainers: vi.fn(),
+}));
+vi.mock("../../hooks/useAutoRefresh", () => ({
+  useAutoRefresh: vi.fn(),
 }));
 vi.mock("./StatsCell", () => ({
   StatsCell: () => <span>StatsCell</span>,
 }));
 
 import { useStackActions } from "../../hooks/useStackActions";
+import { useServiceActions } from "../../hooks/useServiceActions";
 import { useStackContainers } from "../../hooks/useStackContainers";
+import { useAutoRefresh } from "../../hooks/useAutoRefresh";
 const mockUseStackActions = vi.mocked(useStackActions);
+const mockUseServiceActions = vi.mocked(useServiceActions);
 const mockUseStackContainers = vi.mocked(useStackContainers);
+const mockUseAutoRefresh = vi.mocked(useAutoRefresh);
 
 const stack: ComposeStack = {
   Name: "myapp",
@@ -49,11 +59,13 @@ const defaultProps = {
   onBackup: vi.fn(),
   onScale: vi.fn(),
   onActingChange: vi.fn(),
+  onRefresh: vi.fn(),
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseStackActions.mockReturnValue({ acting: false, actionError: null, doAction: vi.fn() });
+  mockUseServiceActions.mockReturnValue({ actingService: null, doServiceAction: vi.fn() });
   mockUseStackContainers.mockReturnValue({
     containers: [],
     loading: false,
@@ -165,6 +177,26 @@ describe("StackRow", () => {
     const dialog = screen.getByRole("dialog");
     fireEvent.click(within(dialog).getByRole("button", { name: /^Stop$/i }));
     expect(doAction).toHaveBeenCalledWith("stop", expect.any(Function));
+  });
+
+  it("calls onRefresh once the stop action's success callback runs (#289)", async () => {
+    // Regression: completing a stack action used to only reload this row's own container
+    // list, never the page-level stack list — so the top-level status badge only updated on
+    // the next scheduled poll, which can now be several seconds out on slow hardware, making
+    // a finished action look stuck. The success callback passed to doAction must also call
+    // onRefresh so the page-level list updates immediately.
+    const doAction = vi.fn();
+    mockUseStackActions.mockReturnValue({ acting: false, actionError: null, doAction });
+    const onRefresh = vi.fn();
+    render(<StackRow {...defaultProps} onRefresh={onRefresh} />);
+    fireEvent.click(screen.getByRole("button", { name: /^Stop$/i }));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Stop$/i }));
+
+    const afterAction = doAction.mock.calls[0][1] as () => Promise<void>;
+    expect(onRefresh).not.toHaveBeenCalled();
+    await act(async () => { await afterAction(); });
+    expect(onRefresh).toHaveBeenCalledOnce();
   });
 
   it("calls doAction with start when Start button clicked on a down stack", () => {
@@ -435,6 +467,30 @@ describe("StackRow", () => {
     it("omits the visible modifier class when nothing is selected", () => {
       const { container } = render(<StackRow {...defaultProps} onToggleSelect={vi.fn()} anySelected={false} />);
       expect(container.querySelector(".sr-check--visible")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("container polling pause (#289)", () => {
+    it("does not pause polling by default (no other action in flight)", () => {
+      render(<StackRow {...defaultProps} />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, false);
+    });
+
+    it("pauses polling while another action is in flight elsewhere on the page", () => {
+      render(<StackRow {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, true);
+    });
+
+    it("does not pause polling for this row's own stack action, even while globalActing", () => {
+      mockUseStackActions.mockReturnValue({ acting: true, actionError: null, doAction: vi.fn() });
+      render(<StackRow {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 500, false);
+    });
+
+    it("does not pause polling for this row's own service action, even while globalActing", () => {
+      mockUseServiceActions.mockReturnValue({ actingService: "web", doServiceAction: vi.fn() });
+      render(<StackRow {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, false);
     });
   });
 });

--- a/src/components/StacksView/StackRow.tsx
+++ b/src/components/StacksView/StackRow.tsx
@@ -79,12 +79,14 @@ interface StackRowProps {
   onBackup: () => void;
   onScale: () => void;
   onActingChange: (delta: 1 | -1) => void;
+  onRefresh: () => void;
   isSelected?: boolean;
   onToggleSelect?: () => void;
   anySelected?: boolean;
+  globalActing?: boolean;
 }
 
-export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull, onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange, isSelected = false, onToggleSelect, anySelected = false }: StackRowProps) {
+export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull, onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange, onRefresh, isSelected = false, onToggleSelect, anySelected = false, globalActing = false }: StackRowProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmStopOpen, setConfirmStopOpen] = useState(false);
@@ -102,7 +104,10 @@ export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, on
   const status = effectiveStatus(baseStatus, containers);
 
   useEffect(() => { void loadContainers(); }, [loadContainers]);
-  useAutoRefresh(loadContainers, acting ? 500 : 3000, false);
+  // Pause this row's own polling while some *other* action is in flight elsewhere on the
+  // page (bulk op, another row) — but never while this row's own action is what's running,
+  // since the faster 500ms interval above exists specifically to show that action's progress.
+  useAutoRefresh(loadContainers, acting ? 500 : 3000, globalActing && !acting && !actingService);
 
   const handleToggle = () => {
     onToggle();
@@ -114,7 +119,16 @@ export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, on
   const afterAction = useCallback(async () => {
     clearContainers();
     if (expanded) await loadContainers();
-  }, [clearContainers, expanded, loadContainers]);
+    // Refresh the page-level stack list immediately rather than waiting for its own poll
+    // (which can now be backed off several seconds on constrained hardware) — otherwise a
+    // finished action looks stuck until the next scheduled tick happens to land.
+    onRefresh();
+  }, [clearContainers, expanded, loadContainers, onRefresh]);
+
+  const afterServiceAction = useCallback(async () => {
+    await loadContainers();
+    onRefresh();
+  }, [loadContainers, onRefresh]);
 
   const healthSummary = stackHealthSummary(containers);
 
@@ -371,9 +385,9 @@ export function StackRow({ stack, expanded, onToggle, onLogs, onYaml, onInfo, on
               containers={containers}
               actions={{
                 actingService,
-                onStart: s => { void doServiceAction("start", s, loadContainers); },
-                onStop: s => { void doServiceAction("stop", s, loadContainers); },
-                onRestart: s => { void doServiceAction("restart", s, loadContainers); },
+                onStart: s => { void doServiceAction("start", s, afterServiceAction); },
+                onStop: s => { void doServiceAction("stop", s, afterServiceAction); },
+                onRestart: s => { void doServiceAction("restart", s, afterServiceAction); },
                 onLogs: s => setLogsService(s),
               }}
             />

--- a/src/components/StacksView/UnixRow.test.tsx
+++ b/src/components/StacksView/UnixRow.test.tsx
@@ -29,10 +29,12 @@ import { useStackActions } from "../../hooks/useStackActions";
 import { useServiceActions } from "../../hooks/useServiceActions";
 import { useStackContainers } from "../../hooks/useStackContainers";
 import { useContainerStats } from "../../hooks/useContainerStats";
+import { useAutoRefresh } from "../../hooks/useAutoRefresh";
 const mockUseStackActions = vi.mocked(useStackActions);
 const mockUseServiceActions = vi.mocked(useServiceActions);
 const mockUseStackContainers = vi.mocked(useStackContainers);
 const mockUseContainerStats = vi.mocked(useContainerStats);
+const mockUseAutoRefresh = vi.mocked(useAutoRefresh);
 
 async function click(element: Element) {
   await act(async () => {
@@ -63,6 +65,7 @@ const defaultProps = {
   onBackup: vi.fn(),
   onScale: vi.fn(),
   onActingChange: vi.fn(),
+  onRefresh: vi.fn(),
 };
 
 beforeEach(() => {
@@ -315,6 +318,30 @@ describe("UnixRow", () => {
 
       rerender(<UnixRow {...defaultProps} onToggleSelect={onToggleSelect} isSelected={true} />);
       expect(screen.getByText("[x]")).toBeInTheDocument();
+    });
+  });
+
+  describe("container polling pause (#289)", () => {
+    it("does not pause polling by default (no other action in flight)", () => {
+      render(<UnixRow {...defaultProps} />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, false);
+    });
+
+    it("pauses polling while another action is in flight elsewhere on the page", () => {
+      render(<UnixRow {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, true);
+    });
+
+    it("does not pause polling for this row's own stack action, even while globalActing", () => {
+      mockUseStackActions.mockReturnValue({ acting: true, actionError: null, doAction: vi.fn() });
+      render(<UnixRow {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 500, false);
+    });
+
+    it("does not pause polling for this row's own service action, even while globalActing", () => {
+      mockUseServiceActions.mockReturnValue({ actingService: "web", doServiceAction: vi.fn() });
+      render(<UnixRow {...defaultProps} globalActing />);
+      expect(mockUseAutoRefresh).toHaveBeenLastCalledWith(expect.any(Function), 3000, false);
     });
   });
 });

--- a/src/components/StacksView/UnixRow.tsx
+++ b/src/components/StacksView/UnixRow.tsx
@@ -58,8 +58,10 @@ interface UnixRowProps {
   onBackup: () => void;
   onScale: () => void;
   onActingChange: (delta: 1 | -1) => void;
+  onRefresh: () => void;
   isSelected?: boolean;
   onToggleSelect?: () => void;
+  globalActing?: boolean;
 }
 
 const STATUS_LABEL: Record<string, { text: string; cls: string }> = {
@@ -72,8 +74,8 @@ const STATUS_LABEL: Record<string, { text: string; cls: string }> = {
 
 export function UnixRow({
   stack, expanded, onToggle, onLogs, onYaml, onInfo, onDown, onKill, onUp, onPull,
-  onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange,
-  isSelected = false, onToggleSelect,
+  onEvents, onTop, onExec, onRun, onPrune, onBackup, onScale, onActingChange, onRefresh,
+  isSelected = false, onToggleSelect, globalActing = false,
 }: UnixRowProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -96,7 +98,16 @@ export function UnixRow({
   const afterAction = useCallback(async () => {
     clearContainers();
     await loadContainers();
-  }, [clearContainers, loadContainers]);
+    // Refresh the page-level stack list immediately rather than waiting for its own poll
+    // (which can now be backed off several seconds on constrained hardware) — otherwise a
+    // finished action looks stuck until the next scheduled tick happens to land.
+    onRefresh();
+  }, [clearContainers, loadContainers, onRefresh]);
+
+  const afterServiceAction = useCallback(async () => {
+    await loadContainers();
+    onRefresh();
+  }, [loadContainers, onRefresh]);
 
   const handleToggle = () => {
     onToggle();
@@ -104,7 +115,7 @@ export function UnixRow({
   };
 
   useEffect(() => { void loadContainers(); }, [loadContainers]);
-  useAutoRefresh(loadContainers, acting ? 500 : 3000, false);
+  useAutoRefresh(loadContainers, acting ? 500 : 3000, globalActing && !acting && !actingService);
 
   const sl = STATUS_LABEL[status] ?? STATUS_LABEL.unknown;
   const isUp = status === "running" || status === "partial" || status === "paused";
@@ -246,9 +257,9 @@ export function UnixRow({
                   containers={containers}
                   actions={{
                     actingService,
-                    onStart: s => { void doServiceAction("start", s, loadContainers); },
-                    onStop: s => { void doServiceAction("stop", s, loadContainers); },
-                    onRestart: s => { void doServiceAction("restart", s, loadContainers); },
+                    onStart: s => { void doServiceAction("start", s, afterServiceAction); },
+                    onStop: s => { void doServiceAction("stop", s, afterServiceAction); },
+                    onRestart: s => { void doServiceAction("restart", s, afterServiceAction); },
                     onLogs: s => setLogsService(s),
                   }}
                 />

--- a/src/components/StacksView/index.tsx
+++ b/src/components/StacksView/index.tsx
@@ -198,7 +198,7 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
   const { sharedNetworks: downSharedNetworks, loading: downNetworksLoading } =
     useSharedNetworks(downTarget?.Name ?? "", downTarget !== null);
 
-  useAutoRefresh(refresh, error ? 2000 : 500, activeOps > 0);
+  useAutoRefresh(refresh, error ? 6000 : 1500, activeOps > 0);
 
   // Keyboard shortcuts: U=up, D=down, L=logs, E=edit, I=info
   useKeyboardShortcuts(
@@ -504,8 +504,10 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onBackup={() => modals.open("backup", stack)}
               onScale={() => modals.open("scale", stack)}
               onActingChange={onActingChange}
+              onRefresh={refresh}
               isSelected={selected.has(stack.Name)}
               onToggleSelect={() => toggleSelect(stack.Name)}
+              globalActing={activeOps > 0}
             />
           ))}
         </div>
@@ -532,8 +534,10 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onBackup={() => modals.open("backup", stack)}
               onScale={() => modals.open("scale", stack)}
               onActingChange={onActingChange}
+              onRefresh={refresh}
               isSelected={selected.has(stack.Name)}
               onToggleSelect={() => toggleSelect(stack.Name)}
+              globalActing={activeOps > 0}
             />
           ))}
         </div>
@@ -570,8 +574,10 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onBackup={() => modals.open("backup", stack)}
               onScale={() => modals.open("scale", stack)}
               onActingChange={onActingChange}
+              onRefresh={refresh}
               isSelected={selected.has(stack.Name)}
               onToggleSelect={() => toggleSelect(stack.Name)}
+              globalActing={activeOps > 0}
             />
           ))}
         </div>
@@ -598,9 +604,11 @@ export function StacksView({ onRuntimeChange, dockerMissing, layout = "poweruser
               onBackup={() => modals.open("backup", stack)}
               onScale={() => modals.open("scale", stack)}
               onActingChange={onActingChange}
+              onRefresh={refresh}
               isSelected={selected.has(stack.Name)}
               onToggleSelect={() => toggleSelect(stack.Name)}
               anySelected={selected.size > 0}
+              globalActing={activeOps > 0}
             />
           ))}
         </DataList>

--- a/src/hooks/useComposeStacks.test.ts
+++ b/src/hooks/useComposeStacks.test.ts
@@ -3,6 +3,11 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { useComposeStacks } from "./useComposeStacks";
 import { mockSpawn } from "../test/setup";
 
+// Lazy: mockSpawn must return a *freshly created* process on each call (not the same
+// eagerly-created one every time), so its data-delivery microtask fires after proc.stream()
+// is registered. listStacks() now tries the engine HTTP API first (an extra async hop before
+// this CLI spawn), so an eagerly-created process would already have resolved with no stream
+// callback registered yet.
 function mockProcess(data: string, error?: string) {
   let streamCb: ((data: string) => void) | null = null;
   const p = new Promise<void>((resolve, reject) => {
@@ -31,14 +36,14 @@ beforeEach(() => {
 
 describe("useComposeStacks", () => {
   it("starts in loading state", async () => {
-    mockSpawn.mockReturnValue(mockProcess("[]"));
+    mockSpawn.mockImplementation(() => mockProcess("[]"));
     const { result } = renderHook(() => useComposeStacks());
     expect(result.current.loading).toBe(true);
     await act(async () => {});
   });
 
   it("returns stacks after successful load", async () => {
-    mockSpawn.mockReturnValue(mockProcess(sampleStacks));
+    mockSpawn.mockImplementation(() => mockProcess(sampleStacks));
     const { result } = renderHook(() => useComposeStacks());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.stacks).toHaveLength(1);
@@ -47,7 +52,7 @@ describe("useComposeStacks", () => {
   });
 
   it("does not surface error before FAIL_THRESHOLD (4) consecutive failures", async () => {
-    mockSpawn.mockReturnValue(mockProcess("", "Internal error"));
+    mockSpawn.mockImplementation(() => mockProcess("", "Internal error"));
     const { result } = renderHook(() => useComposeStacks());
     await waitFor(() => expect(result.current.loading).toBe(false));
     // First failure — should NOT show error yet
@@ -55,7 +60,7 @@ describe("useComposeStacks", () => {
   });
 
   it("surfaces error after FAIL_THRESHOLD consecutive failures", async () => {
-    mockSpawn.mockReturnValue(mockProcess("", "Internal error"));
+    mockSpawn.mockImplementation(() => mockProcess("", "Internal error"));
     const { result } = renderHook(() => useComposeStacks());
 
     // Trigger 4 failures via refresh
@@ -70,7 +75,7 @@ describe("useComposeStacks", () => {
 
   it("clears error on success after failures", async () => {
     // Start with failures to build up fail count
-    mockSpawn.mockReturnValue(mockProcess("", "Internal error"));
+    mockSpawn.mockImplementation(() => mockProcess("", "Internal error"));
     const { result } = renderHook(() => useComposeStacks());
 
     for (let i = 0; i < 4; i++) {
@@ -80,14 +85,14 @@ describe("useComposeStacks", () => {
     await waitFor(() => expect(result.current.error).not.toBeNull());
 
     // Now return success
-    mockSpawn.mockReturnValue(mockProcess(sampleStacks));
+    mockSpawn.mockImplementation(() => mockProcess(sampleStacks));
     act(() => result.current.refresh());
     await waitFor(() => expect(result.current.error).toBeNull());
     expect(result.current.stacks).toHaveLength(1);
   });
 
   it("refresh function triggers re-fetch", async () => {
-    mockSpawn.mockReturnValue(mockProcess(sampleStacks));
+    mockSpawn.mockImplementation(() => mockProcess(sampleStacks));
     const { result } = renderHook(() => useComposeStacks());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -97,15 +102,58 @@ describe("useComposeStacks", () => {
   });
 
   it("handles null/empty JSON response gracefully", async () => {
-    mockSpawn.mockReturnValue(mockProcess("null"));
+    mockSpawn.mockImplementation(() => mockProcess("null"));
     const { result } = renderHook(() => useComposeStacks());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.stacks).toEqual([]);
     expect(result.current.error).toBeNull();
   });
 
+  it("does not start a new fetch while a previous refresh is still in flight, but runs one more as soon as it settles (#289)", async () => {
+    // refresh() itself returns instantly (it just bumps a tick) — the real fetch happens in a
+    // separate effect, so a naive re-fetch-on-every-tick would let calls pile up on slow
+    // hardware exactly like the un-paced polling this hook is meant to avoid. But a refresh()
+    // that arrives mid-fetch isn't just dropped either — e.g. a stack action finishing calls
+    // refresh() to show the result right away, and simply discarding that (leaving it to the
+    // next *scheduled* poll, possibly several seconds out on constrained hardware) would make
+    // a completed action look stuck. So: skip starting a second concurrent fetch, but run
+    // exactly one more immediately once the in-flight one settles.
+    let resolveFirst: (() => void) | undefined;
+    let liveStreamCb: ((data: string) => void) | undefined;
+    let callCount = 0;
+    mockSpawn.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        const p = new Promise<void>(resolve => { resolveFirst = resolve; });
+        return Object.assign(p, {
+          stream: (cb: (data: string) => void) => { liveStreamCb = cb; },
+          close: vi.fn(),
+        });
+      }
+      return mockProcess(sampleStacks);
+    });
+
+    const { result } = renderHook(() => useComposeStacks());
+    // listStacks() tries the engine HTTP API first (a chain of async hops) before reaching
+    // this CLI spawn, so the first call only lands after those settle, not synchronously.
+    await waitFor(() => expect(callCount).toBe(1));
+
+    // A second refresh fires while the first fetch is still pending — it must be skipped,
+    // not started as a second concurrent spawn.
+    act(() => result.current.refresh());
+    expect(callCount).toBe(1);
+
+    // Resolving the first (now-superseded) fetch should immediately trigger the coalesced
+    // follow-up — no further refresh() call needed.
+    liveStreamCb?.(sampleStacks);
+    resolveFirst?.();
+    await waitFor(() => expect(callCount).toBe(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.stacks).toHaveLength(1);
+  });
+
   it("shows Docker-not-found message when error includes 'not found'", async () => {
-    mockSpawn.mockReturnValue(mockProcess("", "docker: command not found"));
+    mockSpawn.mockImplementation(() => mockProcess("", "docker: command not found"));
     const { result } = renderHook(() => useComposeStacks());
 
     // Trigger FAIL_THRESHOLD (4) consecutive failures

--- a/src/hooks/useComposeStacks.ts
+++ b/src/hooks/useComposeStacks.ts
@@ -22,6 +22,8 @@ export function useComposeStacks(): UseComposeStacksResult {
   const [tick, setTick] = useState(0);
   const firstLoadRef = useRef(true);
   const failCountRef = useRef(0);
+  const inFlightRef = useRef(false);
+  const pendingRef = useRef(false);
 
   const refresh = useCallback(() => setTick(t => t + 1), []);
 
@@ -39,39 +41,64 @@ export function useComposeStacks(): UseComposeStacksResult {
     let cancelled = false;
 
     async function load() {
-      if (firstLoadRef.current) {
-        setLoading(true);
-        firstLoadRef.current = false;
-      }
-      if (cancelled) return;
-
-      let raw = "";
-      const proc = listStacks();
-      proc.stream(data => { raw += data; });
+      // refresh() (bumping `tick`) returns instantly — it doesn't wait for this fetch to
+      // complete. On slow hardware, listStacks() can still be running when the next scheduled
+      // refresh() fires, and without this guard a new fetch would start on top of it, piling
+      // up subprocess spawns exactly like the un-paced polling this hook was meant to avoid.
+      // A tick that arrives while one is already in flight isn't just dropped, though — e.g. a
+      // stack action finishing calls refresh() to show the result immediately, and simply
+      // discarding that (leaving it to the next *scheduled* poll, now backed off to several
+      // seconds on constrained hardware) would make completed actions look stuck. So: skip
+      // starting a second concurrent fetch, but remember one more run was requested and run it
+      // immediately once the current one finishes, instead of waiting out the full interval.
+      if (inFlightRef.current) { pendingRef.current = true; return; }
+      inFlightRef.current = true;
       try {
-        await proc;
+        if (firstLoadRef.current) {
+          setLoading(true);
+          firstLoadRef.current = false;
+        }
         if (cancelled) return;
-        failCountRef.current = 0;
-        setStacks(parseJsonOutput<ComposeStack>(raw));
-        setLoading(false);
-        setError(null);
-      } catch (ex: unknown) {
-        if (cancelled) return;
-        failCountRef.current++;
-        setLoading(false);
-        // Only surface the error after several consecutive failures so that
-        // transient Docker "Internal error" responses during restart/stop/pull
-        // don't flash the error banner and kill the refresh interval.
-        if (failCountRef.current >= FAIL_THRESHOLD) {
-          const msg = ex instanceof Error ? ex.message : String(ex);
-          let displayMsg = msg;
-          if (msg.toLowerCase().includes("not found") || msg.toLowerCase().includes("no such file")) {
-            displayMsg = "Docker not found. Install Docker with the Compose plugin (docker compose v2) to use this plugin.";
-          } else if (msg.includes("No such command") || msg.includes("no such command")) {
-            displayMsg = "Docker Compose v2 is required but an older version (v1) was detected. Upgrade to Docker Compose v2, or switch to Podman mode.";
+
+        let raw = "";
+        const proc = listStacks();
+        proc.stream(data => { raw += data; });
+        try {
+          await proc;
+          if (cancelled) return;
+          failCountRef.current = 0;
+          setStacks(parseJsonOutput<ComposeStack>(raw));
+          setLoading(false);
+          setError(null);
+        } catch (ex: unknown) {
+          if (cancelled) return;
+          failCountRef.current++;
+          setLoading(false);
+          // Only surface the error after several consecutive failures so that
+          // transient Docker "Internal error" responses during restart/stop/pull
+          // don't flash the error banner and kill the refresh interval.
+          if (failCountRef.current >= FAIL_THRESHOLD) {
+            const msg = ex instanceof Error ? ex.message : String(ex);
+            let displayMsg = msg;
+            if (msg.toLowerCase().includes("not found") || msg.toLowerCase().includes("no such file")) {
+              displayMsg = "Docker not found. Install Docker with the Compose plugin (docker compose v2) to use this plugin.";
+            } else if (msg.includes("No such command") || msg.includes("no such command")) {
+              displayMsg = "Docker Compose v2 is required but an older version (v1) was detected. Upgrade to Docker Compose v2, or switch to Podman mode.";
+            }
+            setError(displayMsg);
+            setStacks([]);
           }
-          setError(displayMsg);
-          setStacks([]);
+        }
+      } finally {
+        inFlightRef.current = false;
+        if (pendingRef.current) {
+          pendingRef.current = false;
+          // Go through a fresh tick rather than calling load() directly: this closure's own
+          // `cancelled` may already be true (e.g. the pending refresh() that set pendingRef
+          // is what caused this effect to be torn down in the first place) — calling load()
+          // recursively here would immediately hit that stale flag and discard its own
+          // results. A new tick mounts a genuinely fresh, uncancelled effect instance.
+          setTick(t => t + 1);
         }
       }
     }

--- a/src/hooks/useContainerStats.test.ts
+++ b/src/hooks/useContainerStats.test.ts
@@ -104,4 +104,42 @@ describe("useContainerStats", () => {
     expect(mockSpawn.mock.calls.length).toBeGreaterThan(callsBefore);
     vi.useRealTimers();
   });
+
+  it("does not overlap polls when a call is slower than the 10s interval (#289)", async () => {
+    // Regression test: this hook used to poll via a raw setInterval with no in-flight guard,
+    // the same pileup-prone pattern already fixed elsewhere for this issue. It now goes
+    // through useAutoRefresh, which must keep at most one call in flight. Each load() does up
+    // to 2 spawns (listContainers, then getContainerStats) — calls 1-2 are the quick initial
+    // mount load; call 3 (the second poll's listContainers) is made to hang.
+    vi.useFakeTimers();
+    let resolveHang: ((v: string) => void) | undefined;
+    let callCount = 0;
+    mockSpawn.mockImplementation(() => {
+      callCount++;
+      if (callCount === 3) {
+        let streamCb: ((d: string) => void) | undefined;
+        const p = new Promise<string>(resolve => { resolveHang = resolve; });
+        return Object.assign(p.then(v => { streamCb?.(v); return v; }), {
+          stream: (cb: (d: string) => void) => { streamCb = cb; },
+          close: vi.fn(),
+        });
+      }
+      return mockProcess(callCount % 2 === 1 ? runningContainersJson : statsJson);
+    });
+
+    renderHook(() => useContainerStats("myapp", "running"));
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); }); // let the initial load settle
+    expect(callCount).toBe(2);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000); });
+    expect(callCount).toBe(3);
+
+    // Advance well past several would-be intervals while that poll is still pending — with
+    // the old setInterval behavior this would fire several additional overlapping calls.
+    await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+    expect(callCount).toBe(3);
+
+    await act(async () => { resolveHang?.(runningContainersJson); await Promise.resolve(); });
+    vi.useRealTimers();
+  });
 });

--- a/src/hooks/useContainerStats.ts
+++ b/src/hooks/useContainerStats.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { listContainers, getContainerStats, parsePortsFull, parseJsonOutput, parseDockerBytes } from "../api";
 import type { ComposeContainer, ContainerStats, ParsedPort, StackStatus } from "../api";
+import { useAutoRefresh } from "./useAutoRefresh";
 
 const BIND_PRIORITY: Record<ParsedPort["bindType"], number> = { external: 3, specific: 2, localhost: 1 };
 
@@ -60,13 +61,8 @@ export function useContainerStats(stackName: string, status: StackStatus) {
     }
   }, [stackName, status]);
 
-  useEffect(() => {
-    void load();
-    if (status === "running" || status === "partial") {
-      const t = setInterval(() => void load(), 10000);
-      return () => clearInterval(t);
-    }
-  }, [load, status]);
+  useEffect(() => { void load(); }, [load]);
+  useAutoRefresh(load, 10000, !(status === "running" || status === "partial"));
 
   return { ports, stats };
 }

--- a/src/hooks/useStackContainers.test.ts
+++ b/src/hooks/useStackContainers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useStackContainers } from "./useStackContainers";
 import { mockSpawn } from "../test/setup";
@@ -161,5 +161,51 @@ services:
     void act(() => { void result.current.load(); });
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.containers).toHaveLength(2);
+  });
+
+  describe("service name caching (#289)", () => {
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    it("does not re-read the compose file on a poll shortly after the previous read", async () => {
+      mockSpawn
+        .mockImplementationOnce(lazy(runningContainersJson))
+        .mockImplementationOnce(lazy(composeYaml));
+
+      const { result } = renderHook(() =>
+        useStackContainers("myapp", ["/path/compose.yml"], "running"),
+      );
+      void act(() => { void result.current.load(); });
+      await waitFor(() => expect(result.current.containers).toHaveLength(2));
+      expect(mockSpawn).toHaveBeenCalledTimes(2);
+
+      // Second poll, immediately after — only the container list should be spawned;
+      // the compose file read should be served from cache, no extra process spawned.
+      mockSpawn.mockImplementationOnce(lazy(runningContainersJson));
+      void act(() => { void result.current.load(); });
+      await waitFor(() => expect(result.current.containers).toHaveLength(2));
+      expect(mockSpawn).toHaveBeenCalledTimes(3);
+    });
+
+    it("re-reads the compose file again once the cache expires", async () => {
+      mockSpawn
+        .mockImplementationOnce(lazy(runningContainersJson))
+        .mockImplementationOnce(lazy(composeYaml));
+
+      const { result } = renderHook(() =>
+        useStackContainers("myapp", ["/path/compose.yml"], "running"),
+      );
+      void act(() => { void result.current.load(); });
+      await waitFor(() => expect(result.current.containers).toHaveLength(2));
+      expect(mockSpawn).toHaveBeenCalledTimes(2);
+
+      const realNow = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(realNow + 31_000);
+
+      mockSpawn
+        .mockImplementationOnce(lazy(runningContainersJson))
+        .mockImplementationOnce(lazy(composeYaml));
+      void act(() => { void result.current.load(); });
+      await waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(4));
+    });
   });
 });

--- a/src/hooks/useStackContainers.ts
+++ b/src/hooks/useStackContainers.ts
@@ -9,6 +9,14 @@ import {
 } from "../api";
 
 
+// Service names are re-derived from the compose file(s) on every poll, but those files
+// virtually never change while a stack is sitting on the page — so re-reading (and
+// re-spawning a process) for them on every tick is wasted work, disproportionately costly
+// on constrained hardware. Cache them for a while instead of forever: long enough to avoid
+// re-reading on every poll, short enough to still pick up changes made outside this app
+// (another tool, an external edit) within a bounded time.
+const SERVICE_NAMES_TTL_MS = 30_000;
+
 async function readServiceNames(configFiles: string[]): Promise<string[]> {
   const seen = new Set<string>();
   const result: string[] = [];
@@ -28,6 +36,7 @@ export function useStackContainers(stackName: string, configFiles: string[], sta
   const [containers, setContainers] = useState<ComposeContainer[]>([]);
   const [loading, setLoading] = useState(false);
   const cachedServiceNamesRef = useRef<string[]>([]);
+  const serviceNamesReadAtRef = useRef(0);
   const prevStatusRef = useRef<StackStatus>("unknown");
   const hasDataRef = useRef(false);
   const hasContainersRef = useRef(false);
@@ -42,6 +51,24 @@ export function useStackContainers(stackName: string, configFiles: string[], sta
   }, [status]);
 
   const configFilesKey = configFiles.join(",");
+
+  // The caller's config files can change (e.g. a stack's compose file list is edited)
+  // independent of the TTL above — force a fresh read the next time that happens.
+  useEffect(() => {
+    serviceNamesReadAtRef.current = 0;
+  }, [configFilesKey]);
+
+  const getServiceNames = useCallback(async (): Promise<string[]> => {
+    const isFresh = cachedServiceNamesRef.current.length > 0
+      && Date.now() - serviceNamesReadAtRef.current < SERVICE_NAMES_TTL_MS;
+    if (isFresh) return cachedServiceNamesRef.current;
+    const names = await readServiceNames(configFiles);
+    cachedServiceNamesRef.current = names;
+    serviceNamesReadAtRef.current = Date.now();
+    return names;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configFilesKey]);
+
   const load = useCallback(async () => {
     if (!hasDataRef.current && !hasContainersRef.current) setLoading(true);
     try {
@@ -51,8 +78,7 @@ export function useStackContainers(stackName: string, configFiles: string[], sta
       await proc;
       const running = parseJsonOutput<ComposeContainer>(raw);
 
-      const serviceNames = await readServiceNames(configFiles);
-      cachedServiceNamesRef.current = serviceNames;
+      const serviceNames = await getServiceNames();
 
       hasDataRef.current = true;
       const next = serviceNames.flatMap(name => {
@@ -63,8 +89,7 @@ export function useStackContainers(stackName: string, configFiles: string[], sta
       setContainers(next);
     } catch {
       try {
-        const serviceNames = await readServiceNames(configFiles);
-        cachedServiceNamesRef.current = serviceNames;
+        const serviceNames = await getServiceNames();
         const fallback = serviceNames.map(name => ({
           ID: "", Name: name, Image: "", State: "down", Status: "down", Ports: "", Service: name,
         }));
@@ -82,7 +107,7 @@ export function useStackContainers(stackName: string, configFiles: string[], sta
       setLoading(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stackName, configFilesKey]);
+  }, [stackName, configFilesKey, getServiceNames]);
 
   const clear = useCallback(() => { hasDataRef.current = false; hasContainersRef.current = false; setContainers([]); }, []);
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -10,8 +10,19 @@ const mockPermission = {
   close: vi.fn(),
 };
 
+// Fails by default so existing tests (which only mock `spawn`) keep exercising the CLI
+// fallback path unaffected. Tests exercising the HTTP-first path override this per-test with
+// `mockHttp.mockReturnValue(mockHttpClient({...}))` (from the base package's testing helpers).
+const mockHttp = vi.fn((): CockpitHttpClient => ({
+  get: vi.fn(() => Promise.reject(new Error("cockpit.http not mocked in this test"))),
+  post: vi.fn(() => Promise.reject(new Error("cockpit.http not mocked in this test"))),
+  request: vi.fn(() => Promise.reject(new Error("cockpit.http not mocked in this test"))),
+  close: vi.fn(),
+}));
+
 vi.stubGlobal("cockpit", {
   spawn: mockSpawn,
+  http: mockHttp,
   permission: vi.fn().mockReturnValue(mockPermission),
 });
 
@@ -19,4 +30,4 @@ vi.stubGlobal("cockpit", {
 // i18n's cockpitDetector runs localStorage.getItem()
 await import("../i18n");
 
-export { mockSpawn };
+export { mockSpawn, mockHttp };


### PR DESCRIPTION
## Summary
Fixes #289 — high CPU usage on slow/low-power hardware, caused by several compounding polling issues:

- **Main change**: `listContainers()`/`listStacks()` now try the container engine's REST API directly over its Unix socket first (reusing existing rootless/rootful socket detection), falling back to the exact prior CLI behavior on any failure. Process-spawn overhead dominates per-poll cost, so this cuts it ~10x. Scoped to pure reads only — every write path (up/down/pull/exec/logs/events/etc.) is untouched.
- `useComposeStacks` had no guard against a new fetch starting while a prior poll-triggered one was still in flight, letting subprocess spawns pile up. Now skips a redundant fetch but coalesces exactly one follow-up run, so a refresh triggered right after finishing a stack action is never silently dropped.
- `useContainerStats` was still polling via a raw `setInterval` with no overlap protection; migrated to `useAutoRefresh`.
- Each stack's compose file was re-read on every poll just to recompute service names; now cached for 30s.
- Top-level stack list poll interval tightened from 500ms/2000ms to 1500ms/6000ms (idle/error).
- Stack/service actions only refreshed their own row locally, never the page-level summary — invisible at 500ms polling, but left completed actions looking stuck once the interval above was slowed down. All four row layouts now trigger an immediate page-level refresh on action success.

Requires `@rxtx4816/cockpit-plugin-base-react` >=1.1.3 (already bumped in this PR) for the companion `useAutoRefresh` self-pacing/backoff fix — see [RXTX4816/cockpit-plugin-base-react#129](https://github.com/RXTX4816/cockpit-plugin-base-react/pull/129).

## Test plan
- [x] `npm run test` — 1587 tests pass, run against the real published base-react 1.1.3 (not the local yalc link)
- [x] `npm run lint` / `npm run typecheck` — clean
- [x] Manually verified in QEMU VMs across docker/podman and rootless/rootful — idle CPU dropped from ~25% (pegged, throttled test VM) to ~3-7%