### PR TITLE
fix: move remaining hot-path spawns to cockpit.file()/HTTP

### DIFF
--- a/src/api/cockpit.test.ts
+++ b/src/api/cockpit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mockSpawn } from "../test/setup";
-import { mockProcess } from "../test/helpers";
+import { mockProcess, mockHttpClient } from "../test/helpers";
 
 beforeEach(() => {
   mockSpawn.mockReset();
@@ -190,12 +190,27 @@ describe("checkSocketHealth() / redetectSockets()", () => {
     expect(result).toEqual({ ok: false, reason: "permission denied" });
   });
 
-  it("reports healthy when the probe command succeeds", async () => {
+  it("reports healthy when the CLI probe succeeds (no cockpit.http available)", async () => {
     mockSpawn.mockImplementation(() => mockProcess("socket"));
     const { detectDockerMode, checkSocketHealth } = await import("./cockpit");
     await detectDockerMode();
     const result = await checkSocketHealth("docker", "rootless");
     expect(result).toEqual({ ok: true });
+  });
+
+  it("reports healthy via GET /version over the socket, without spawning a CLI probe at all", async () => {
+    const mockHttp = vi.fn(() => mockHttpClient({ "/version": '{"Version":"24.0.0"}' }));
+    mockSpawn.mockImplementation(() => mockProcess("socket")); // only used for socket detection
+    vi.stubGlobal("cockpit", { spawn: mockSpawn, user: mockUser, http: mockHttp });
+    const { detectDockerMode, checkSocketHealth } = await import("./cockpit");
+    await detectDockerMode();
+    const spawnCallsAfterDetection = mockSpawn.mock.calls.length;
+
+    const result = await checkSocketHealth("docker", "rootless");
+
+    expect(result).toEqual({ ok: true });
+    expect(mockHttp).toHaveBeenCalledWith("/run/user/1000/docker.sock", { superuser: undefined });
+    expect(mockSpawn.mock.calls.length).toBe(spawnCallsAfterDetection); // no additional spawn for the probe
   });
 
   it("reports unavailable when the candidate was never detected", async () => {

--- a/src/api/cockpit.ts
+++ b/src/api/cockpit.ts
@@ -171,11 +171,34 @@ export async function redetectSockets(runtime: Runtime): Promise<void> {
 // socket file exists, but that the daemon/storage behind it responds. Rootful candidates are
 // probed with superuser "try" (mirrors how real commands escalate); if Cockpit's admin-access
 // bridge isn't enabled, this degrades to an unprivileged attempt and reports the real failure.
+//
+// Tried over the socket's own REST API first (GET /version — cheap, and every engine that
+// implements this compat layer serves it) rather than spawning a whole CLI process just to
+// confirm the daemon responds; this runs once per candidate at startup, not on a poll, but
+// process-spawn + bridge dispatch overhead is disproportionately expensive on slow hardware
+// even for a one-off check. Falls back to the exact previous CLI probe (which also supplies a
+// human-readable failure reason) on any failure — this can't be less reliable than before, and
+// this specific runtime/mode combination isn't necessarily the currently *active* selection
+// (the caller may be probing an alternate mode the user hasn't switched to), so this can't
+// reuse the "current selection" HTTP client the polling paths use — it targets this candidate
+// directly.
 export async function checkSocketHealth(runtime: Runtime, mode: SocketMode): Promise<{ ok: boolean; reason?: string }> {
   const candidate = socketInfo[runtime][mode];
   if (!candidate) return { ok: false, reason: "socket not detected" };
 
   const superuser: "try" | undefined = mode === "rootful" ? "try" : undefined;
+
+  const socketPath = candidate.path.replace(/^unix:\/\//, "");
+  try {
+    const http = cockpit.http(socketPath, { superuser });
+    try {
+      await http.get("/version");
+      return { ok: true };
+    } finally {
+      http.close();
+    }
+  } catch { /* fall through to the CLI probe below */ }
+
   const probeArgs = runtime === "podman" ? ["podman", "ps"] : ["docker", "version", "--format", "{{.Server.Version}}"];
   try {
     await cockpit.spawn(probeArgs, { superuser, err: "message", environ: candidate.environ });

--- a/src/api/containers.test.ts
+++ b/src/api/containers.test.ts
@@ -147,6 +147,35 @@ describe("getContainerStats [engine HTTP API]", () => {
     expect(mockSpawn).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to the CLI for Podman's real stats shape, not a wrong CPU% (verified live against a real podman.sock)", async () => {
+    // Podman's compat /containers/{id}/stats?stream=false does NOT provide a real second CPU
+    // sample the way Docker's does — precpu_stats always comes back with total_usage: 0 and no
+    // system_cpu_usage key at all, confirmed by sampling a real running container 3 times, 2s
+    // apart, over a live podman.sock. Plugging that into the delta formula wouldn't throw
+    // (cpu_stats.system_cpu_usage alone is a valid positive number) — it would silently
+    // compute cumulative average CPU since container start, not current CPU%. This must fall
+    // back to the CLI instead of returning that wrong number.
+    const cockpitMod = await import("./cockpit");
+    cockpitMod.setRuntime("podman");
+    vi.spyOn(cockpitMod, "getIsPodman").mockReturnValue(true);
+    vi.spyOn(cockpitMod, "getPodmanSocketPath").mockReturnValue("unix:///run/user/1000/podman/podman.sock");
+    mockHttp.mockReturnValue(mockHttpClient({
+      "/containers/abc123/stats": JSON.stringify({
+        name: "long-logs_web_1",
+        cpu_stats: { cpu_usage: { total_usage: 1343621000 }, system_cpu_usage: 17315571000 },
+        precpu_stats: { cpu_usage: { total_usage: 0 } }, // no system_cpu_usage key — real podman shape
+        memory_stats: { usage: 25436160, limit: 1007079424 }, // no stats.cache key — also real podman shape
+      }),
+    }));
+    mockSpawn.mockImplementation(() => mockProcess("[]"));
+
+    const { getContainerStats: stats } = await import("./containers");
+    const proc = stats(["abc123"]);
+    await proc;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to the CLI when the HTTP request fails outright", async () => {
     const cockpitMod = await import("./cockpit");
     vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");

--- a/src/api/containers.test.ts
+++ b/src/api/containers.test.ts
@@ -76,6 +76,93 @@ describe("listContainers [engine HTTP API]", () => {
   });
 });
 
+describe("getContainerStats [engine HTTP API]", () => {
+  const statsFor = (overrides: { totalUsage: number; preTotalUsage: number; systemUsage: number; preSystemUsage: number; onlineCpus: number; usage: number; cache: number; limit: number }) => JSON.stringify({
+    name: "/myapp_web_1",
+    cpu_stats: { cpu_usage: { total_usage: overrides.totalUsage }, system_cpu_usage: overrides.systemUsage, online_cpus: overrides.onlineCpus },
+    precpu_stats: { cpu_usage: { total_usage: overrides.preTotalUsage }, system_cpu_usage: overrides.preSystemUsage },
+    memory_stats: { usage: overrides.usage, limit: overrides.limit, stats: { cache: overrides.cache } },
+  });
+
+  it("computes CPU% and memory usage from the raw stats sample, skipping the CLI entirely", async () => {
+    const cockpitMod = await import("./cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    mockHttp.mockReturnValue(mockHttpClient({
+      "/containers/abc123/stats": statsFor({
+        totalUsage: 300000000, preTotalUsage: 100000000, // 200ms cpu delta
+        systemUsage: 2000000000, preSystemUsage: 1000000000, // 1s system delta
+        onlineCpus: 2,
+        usage: 104857600, cache: 4857600, limit: 1073741824, // 100MiB used, 1GiB limit
+      }),
+    }));
+
+    const { getContainerStats: stats } = await import("./containers");
+    let received = "";
+    const proc = stats(["abc123"]);
+    proc.stream(d => { received += d; });
+    await proc;
+
+    const result = JSON.parse(received) as { id: string; name: string; cpu: string; mem: string; memPerc: string }[];
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("abc123");
+    expect(result[0].name).toBe("myapp_web_1");
+    // (200ms / 1000ms) * 2 cpus * 100 = 40%
+    expect(result[0].cpu).toBe("40.00%");
+    // 104857600 - 4857600 = 100000000 bytes used
+    expect(result[0].mem).toBe("100000000B / 1073741824B");
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("fetches each container's stats independently in parallel", async () => {
+    const cockpitMod = await import("./cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    mockHttp.mockReturnValue(mockHttpClient({
+      "/containers/c1/stats": statsFor({ totalUsage: 200000000, preTotalUsage: 100000000, systemUsage: 2000000000, preSystemUsage: 1000000000, onlineCpus: 1, usage: 1000, cache: 0, limit: 2000 }),
+      "/containers/c2/stats": statsFor({ totalUsage: 400000000, preTotalUsage: 100000000, systemUsage: 2000000000, preSystemUsage: 1000000000, onlineCpus: 1, usage: 500, cache: 0, limit: 2000 }),
+    }));
+
+    const { getContainerStats: stats } = await import("./containers");
+    let received = "";
+    const proc = stats(["c1", "c2"]);
+    proc.stream(d => { received += d; });
+    await proc;
+
+    const result = JSON.parse(received) as { id: string }[];
+    expect(result.map(r => r.id)).toEqual(["c1", "c2"]);
+  });
+
+  it("falls back to the CLI when a stats sample can't yield a usable CPU delta", async () => {
+    const cockpitMod = await import("./cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    // system_cpu_usage delta is zero — a degenerate sample that can't produce a percentage.
+    mockHttp.mockReturnValue(mockHttpClient({
+      "/containers/abc123/stats": statsFor({ totalUsage: 100, preTotalUsage: 0, systemUsage: 1000, preSystemUsage: 1000, onlineCpus: 1, usage: 0, cache: 0, limit: 0 }),
+    }));
+    mockSpawn.mockImplementation(() => mockProcess("[]"));
+
+    const { getContainerStats: stats } = await import("./containers");
+    const proc = stats(["abc123"]);
+    await proc;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the CLI when the HTTP request fails outright", async () => {
+    const cockpitMod = await import("./cockpit");
+    vi.spyOn(cockpitMod, "getDockerSocketPath").mockReturnValue("unix:///var/run/docker.sock");
+    const failingClient = mockHttpClient();
+    vi.spyOn(failingClient, "get").mockRejectedValue(new Error("connection refused"));
+    mockHttp.mockReturnValue(failingClient);
+    mockSpawn.mockImplementation(() => mockProcess("[]"));
+
+    const { getContainerStats: stats } = await import("./containers");
+    const proc = stats(["abc123"]);
+    await proc;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("listContainers [docker]", () => {
   it("spawns compose ps --all --format json for the project", async () => {
     mockSpawn.mockReturnValue(mockProcess("[]"));
@@ -146,9 +233,11 @@ describe("listContainers [podman error handling]", () => {
 });
 
 describe("getContainerStats", () => {
-  it("spawns docker stats --no-stream with the given container IDs", () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
-    getContainerStats(["abc123", "def456"]);
+  it("spawns docker stats --no-stream with the given container IDs", async () => {
+    // getContainerStats() tries the engine HTTP API first (mocked to fail by default — see
+    // test/setup.ts), then falls back to the CLI spawn asserted on below, asynchronously.
+    mockSpawn.mockImplementation(() => mockProcess(""));
+    await getContainerStats(["abc123", "def456"]).catch(() => {});
     const args = mockSpawn.mock.calls[0][0] as string[];
     expect(args).toContain("docker");
     expect(args).toContain("stats");
@@ -157,9 +246,9 @@ describe("getContainerStats", () => {
     expect(args).toContain("def456");
   });
 
-  it("includes a JSON format template in the args", () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
-    getContainerStats(["abc"]);
+  it("includes a JSON format template in the args", async () => {
+    mockSpawn.mockImplementation(() => mockProcess(""));
+    await getContainerStats(["abc"]).catch(() => {});
     const args = mockSpawn.mock.calls[0][0] as string[];
     const formatArg = args.find(a => a.includes("{{.CPUPerc}}"));
     expect(formatArg).toBeDefined();
@@ -169,8 +258,8 @@ describe("getContainerStats", () => {
     const cockpitMod = await import("./cockpit");
     cockpitMod.setRuntime("podman");
     const { getContainerStats: stats } = await import("./containers");
-    mockSpawn.mockReturnValue(mockProcess(""));
-    stats(["abc"]);
+    mockSpawn.mockImplementation(() => mockProcess(""));
+    await stats(["abc"]).catch(() => {});
     const args = mockSpawn.mock.calls[0][0] as string[];
     const formatArg = args.find(a => a.includes("{{.CPU}}"));
     expect(formatArg).toBeDefined();
@@ -251,9 +340,9 @@ describe("superuser escalation (rootful Podman)", () => {
     expect(opts.superuser).toBe("try");
   });
 
-  it("getContainerStats passes superuser:'try'", () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
-    getContainerStats(["abc123"]);
+  it("getContainerStats passes superuser:'try'", async () => {
+    mockSpawn.mockImplementation(() => mockProcess(""));
+    await getContainerStats(["abc123"]).catch(() => {});
     const opts = mockSpawn.mock.calls[0][1] as { superuser?: string };
     expect(opts.superuser).toBe("try");
   });

--- a/src/api/containers.ts
+++ b/src/api/containers.ts
@@ -1,6 +1,10 @@
 import { compose, cli, getIsPodman, dockerSpawnEnviron, composeIsLimitedBackend, socketSuperuser } from "./cockpit";
 import { engineHttpGetJson, drainProcess } from "./engineHttp";
-import { type EngineContainerJson, engineContainerName, enginePortsToString, isOneoffContainer } from "./engineJson";
+import {
+  type EngineContainerJson, type EngineContainerStatsJson,
+  engineContainerName, enginePortsToString, isOneoffContainer,
+  engineCpuPercent, engineMemoryUsageBytes,
+} from "./engineJson";
 import { makeFakeProcess } from "./stacks/internal";
 
 interface PodmanPort {
@@ -113,7 +117,32 @@ export function listContainers(project: string): CockpitProcess {
   });
 }
 
-export function getContainerStats(containerIds: string[]): CockpitProcess {
+// Pure read, tried over the engine's REST API first — same rationale as listContainers().
+// Unlike the CLI's `docker stats id1 id2 ...` (one call for every container), the Engine API
+// has no batch form: one GET /containers/{id}/stats per container, run in parallel. That's
+// still a clear win here since process-spawn overhead — not the number of HTTP round trips —
+// dominates the cost on constrained hardware. Any single container's stats failing to parse
+// (or the whole batch failing) falls back to the exact previous CLI behavior.
+async function getContainerStatsHttp(containerIds: string[]): Promise<string> {
+  const results = await Promise.all(containerIds.map(async id => {
+    const s = await engineHttpGetJson<EngineContainerStatsJson>(`/containers/${id}/stats`, { stream: "false" });
+    const cpuPercent = engineCpuPercent(s);
+    const usage = engineMemoryUsageBytes(s);
+    const limit = s.memory_stats.limit ?? 0;
+    return {
+      id,
+      name: (s.name ?? "").replace(/^\//, ""),
+      cpu: `${cpuPercent.toFixed(2)}%`,
+      mem: `${usage}B / ${limit}B`,
+      memPerc: limit > 0 ? `${((usage / limit) * 100).toFixed(2)}%` : "0.00%",
+      net: "",
+      block: "",
+    };
+  }));
+  return JSON.stringify(results);
+}
+
+function getContainerStatsCli(containerIds: string[]): CockpitProcess {
   const cpuField = getIsPodman() ? "{{.CPU}}" : "{{.CPUPerc}}";
   return cockpit.spawn(
     cli("stats", "--no-stream",
@@ -123,4 +152,14 @@ export function getContainerStats(containerIds: string[]): CockpitProcess {
     ),
     { superuser: socketSuperuser(), err: "message", ...dockerSpawnEnviron() },
   );
+}
+
+export function getContainerStats(containerIds: string[]): CockpitProcess {
+  return makeFakeProcess(async () => {
+    try {
+      return await getContainerStatsHttp(containerIds);
+    } catch {
+      return await drainProcess(getContainerStatsCli(containerIds));
+    }
+  });
 }

--- a/src/api/engineJson.ts
+++ b/src/api/engineJson.ts
@@ -38,3 +38,50 @@ export function enginePortsToString(ports: EngineContainerPort[] | undefined): s
 export function isOneoffContainer(c: EngineContainerJson): boolean {
   return c.Labels?.["com.docker.compose.oneoff"]?.toLowerCase() === "true";
 }
+
+// Shape of GET /containers/{id}/stats?stream=false. `precpu_stats` is a second, slightly
+// earlier CPU sample the daemon already takes internally even for a single non-streaming
+// response — that's what makes a CPU percentage computable from one HTTP call, matching what
+// `docker stats --no-stream` shows from one CLI invocation.
+export interface EngineContainerStatsJson {
+  id?: string;
+  name?: string;
+  cpu_stats: {
+    cpu_usage: { total_usage: number };
+    system_cpu_usage?: number;
+    online_cpus?: number;
+    percpu_usage?: number[];
+  };
+  precpu_stats: {
+    cpu_usage: { total_usage: number };
+    system_cpu_usage?: number;
+  };
+  memory_stats: {
+    usage?: number;
+    limit?: number;
+    stats?: { cache?: number };
+  };
+}
+
+// Docker's own CPU% formula (matches what `docker stats`/`CLI --format {{.CPUPerc}}` shows):
+// (cpu_delta / system_delta) * number_of_cpus * 100. Throws on a degenerate sample (e.g.
+// system_delta <= 0, which can happen on the very first sample after a container starts, or
+// if a runtime's compat stats endpoint doesn't populate these fields the way Docker's does)
+// rather than returning a nonsensical percentage — callers fall back to the CLI in that case.
+export function engineCpuPercent(s: EngineContainerStatsJson): number {
+  const cpuDelta = s.cpu_stats.cpu_usage.total_usage - s.precpu_stats.cpu_usage.total_usage;
+  const systemDelta = (s.cpu_stats.system_cpu_usage ?? 0) - (s.precpu_stats.system_cpu_usage ?? 0);
+  if (systemDelta <= 0 || cpuDelta < 0) {
+    throw new Error("engineCpuPercent: degenerate stats sample (no usable delta)");
+  }
+  const cpuCount = s.cpu_stats.online_cpus ?? s.cpu_stats.percpu_usage?.length ?? 1;
+  return (cpuDelta / systemDelta) * cpuCount * 100;
+}
+
+// Memory "usage" in Docker's stats includes page cache, which `docker stats` itself subtracts
+// out for a more meaningful figure — matches what the CLI's {{.MemUsage}} column shows.
+export function engineMemoryUsageBytes(s: EngineContainerStatsJson): number {
+  const usage = s.memory_stats.usage ?? 0;
+  const cache = s.memory_stats.stats?.cache ?? 0;
+  return Math.max(0, usage - cache);
+}

--- a/src/api/engineJson.ts
+++ b/src/api/engineJson.ts
@@ -64,13 +64,22 @@ export interface EngineContainerStatsJson {
 }
 
 // Docker's own CPU% formula (matches what `docker stats`/`CLI --format {{.CPUPerc}}` shows):
-// (cpu_delta / system_delta) * number_of_cpus * 100. Throws on a degenerate sample (e.g.
-// system_delta <= 0, which can happen on the very first sample after a container starts, or
-// if a runtime's compat stats endpoint doesn't populate these fields the way Docker's does)
-// rather than returning a nonsensical percentage — callers fall back to the CLI in that case.
+// (cpu_delta / system_delta) * number_of_cpus * 100. This only works when precpu_stats is a
+// real, slightly-earlier second sample — true for Docker's own daemon, confirmed *not* true
+// for Podman's compat endpoint: verified live against a real podman.sock that `precpu_stats`
+// always comes back as total_usage=0 with system_cpu_usage omitted entirely, never an actual
+// second sample, however long the container has been running. Silently plugging that into the
+// formula wouldn't crash — cpu_stats.system_cpu_usage alone is still a valid, non-zero number
+// — it would just quietly compute the wrong thing: cumulative average CPU use since container
+// start, not the current instantaneous CPU%. So precpu_stats.system_cpu_usage being absent is
+// treated as a hard signal this sample can't yield a real percentage, same as a non-positive
+// delta — callers fall back to the CLI in both cases, which is correct for Podman.
 export function engineCpuPercent(s: EngineContainerStatsJson): number {
+  if (s.precpu_stats.system_cpu_usage === undefined) {
+    throw new Error("engineCpuPercent: precpu_stats has no system_cpu_usage — not a real second sample");
+  }
   const cpuDelta = s.cpu_stats.cpu_usage.total_usage - s.precpu_stats.cpu_usage.total_usage;
-  const systemDelta = (s.cpu_stats.system_cpu_usage ?? 0) - (s.precpu_stats.system_cpu_usage ?? 0);
+  const systemDelta = (s.cpu_stats.system_cpu_usage ?? 0) - s.precpu_stats.system_cpu_usage;
   if (systemDelta <= 0 || cpuDelta < 0) {
     throw new Error("engineCpuPercent: degenerate stats sample (no usable delta)");
   }

--- a/src/api/files.test.ts
+++ b/src/api/files.test.ts
@@ -10,16 +10,39 @@ const mockCockpitFile = vi.fn().mockReturnValue(mockFileHandle);
 beforeEach(() => {
   mockSpawn.mockReset();
   mockReplace.mockReset().mockResolvedValue(undefined);
-  mockRead.mockReset();
+  // Fails by default so existing cat-spawn-based tests (which only configure mockSpawn) keep
+  // exercising the fallback path unaffected — readComposeFile() now tries cockpit.file() first.
+  mockRead.mockReset().mockRejectedValue(new Error("cockpit.file not mocked in this test"));
   mockCockpitFile.mockReset().mockReturnValue(mockFileHandle);
   vi.stubGlobal("cockpit", { spawn: mockSpawn, file: mockCockpitFile });
 });
 
 describe("readComposeFile", () => {
-  it("spawns cat on the given path", async () => {
+  it("reads via cockpit.file() and skips spawning entirely on success", async () => {
     const { readComposeFile } = await import("./files");
-    mockSpawn.mockReturnValue(mockProcess("content"));
-    readComposeFile("/path/compose.yml");
+    mockRead.mockResolvedValue("content");
+    const content = await readComposeFile("/path/compose.yml");
+    expect(content).toBe("content");
+    expect(mockCockpitFile).toHaveBeenCalledWith("/path/compose.yml", undefined);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("rejects (does not resolve empty) when cockpit.file() reports the file missing", async () => {
+    const { readComposeFile } = await import("./files");
+    mockRead.mockResolvedValue(null); // cockpit.file()'s read() resolves null on ENOENT
+    // Lazy: readComposeFile() takes an async hop (the cockpit.file() attempt) before this
+    // fallback spawn, so an eagerly-created mockProcess would resolve before proc.stream() is
+    // registered — see the identical fix already applied elsewhere for this same race.
+    mockSpawn.mockImplementation(() => mockProcess("", "No such file or directory"));
+    await expect(readComposeFile("/path/missing.yml")).rejects.toThrow();
+  });
+
+  it("falls back to spawning cat when cockpit.file() fails", async () => {
+    const { readComposeFile } = await import("./files");
+    mockRead.mockRejectedValue(new Error("access denied"));
+    mockSpawn.mockImplementation(() => mockProcess("content"));
+    const content = await readComposeFile("/path/compose.yml");
+    expect(content).toBe("content");
     const args = mockSpawn.mock.calls[0][0] as string[];
     expect(args).toEqual(["cat", "/path/compose.yml"]);
   });
@@ -263,21 +286,21 @@ describe("createBackupArchive", () => {
 describe("readAllProfiles", () => {
   it("returns profiles parsed from the compose file", async () => {
     const { readAllProfiles } = await import("./files");
-    mockSpawn.mockReturnValue(mockProcess("services:\n  svc:\n    image: alpine\n    profiles: [dev]\n"));
+    mockSpawn.mockImplementation(() => mockProcess("services:\n  svc:\n    image: alpine\n    profiles: [dev]\n"));
     const profiles = await readAllProfiles("/path/compose.yml");
     expect(profiles).toEqual(["dev"]);
   });
 
   it("returns empty array when spawn rejects", async () => {
     const { readAllProfiles } = await import("./files");
-    mockSpawn.mockReturnValue(mockProcess("", "permission denied"));
+    mockSpawn.mockImplementation(() => mockProcess("", "permission denied"));
     const profiles = await readAllProfiles("/path/compose.yml");
     expect(profiles).toEqual([]);
   });
 
   it("returns empty array when compose file has no profiles", async () => {
     const { readAllProfiles } = await import("./files");
-    mockSpawn.mockReturnValue(mockProcess("services:\n  web:\n    image: nginx\n"));
+    mockSpawn.mockImplementation(() => mockProcess("services:\n  web:\n    image: nginx\n"));
     const profiles = await readAllProfiles("/path/compose.yml");
     expect(profiles).toEqual([]);
   });

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -9,9 +9,28 @@ import {
   type TarCreateResult,
 } from "@rxtx4816/cockpit-plugin-base-react/lib/tar";
 import { readFile, writeFile } from "@rxtx4816/cockpit-plugin-base-react/lib/cockpit-fs";
+import { makeFakeProcess } from "./stacks/internal";
 
+// Reads via Cockpit's own file channel (cockpit.file()) rather than spawning `cat` — this is
+// read far more often than it changes (every stack-list/container poll used to re-spawn it),
+// and cockpit.file() skips the process-spawn cost entirely. Falls back to the exact previous
+// `cat`-based behavior on any failure, so this can't be less reliable than before. Preserves
+// the original contract of rejecting (rather than resolving null) when the file is missing,
+// since every existing caller already handles that via try/catch.
 export function readComposeFile(path: string): CockpitProcess {
-  return cockpit.spawn(["cat", path], { err: "message" });
+  return makeFakeProcess(async () => {
+    try {
+      const content = await readFile(path);
+      if (content === null) throw new Error(`cockpit.file: ${path}: No such file or directory`);
+      return content;
+    } catch {
+      let content = "";
+      const proc = cockpit.spawn(["cat", path], { err: "message" });
+      proc.stream((d: string) => { content += d; });
+      await proc;
+      return content;
+    }
+  });
 }
 
 export async function readAllProfiles(configFile: string): Promise<string[]> {

--- a/src/components/ExecModal.test.tsx
+++ b/src/components/ExecModal.test.tsx
@@ -66,14 +66,14 @@ beforeEach(() => {
 
 describe("ExecModal", () => {
   it("renders modal title with stack name", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     expect(screen.getByText(/Shell — myapp/i)).toBeInTheDocument();
     await act(async () => {});
   });
 
   it("shows config step by default", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     expect(screen.getByLabelText(/Command/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Open shell/i })).toBeInTheDocument();
@@ -81,14 +81,14 @@ describe("ExecModal", () => {
   });
 
   it("populates service selector from compose YAML", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByRole("option", { name: "web" })).toBeInTheDocument());
     expect(screen.getByRole("option", { name: "db" })).toBeInTheDocument();
   });
 
   it("defaults shell to /bin/sh", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     const shellInput = screen.getByLabelText(/Command/i) as HTMLInputElement & { value: string };
     expect(shellInput.value).toBe("/bin/sh");
@@ -96,7 +96,7 @@ describe("ExecModal", () => {
   });
 
   it("Open shell button is disabled when service is empty", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     // No services loaded (file returned nothing) and no manual input
     const btn = screen.getByRole("button", { name: /Open shell/i });
@@ -105,7 +105,7 @@ describe("ExecModal", () => {
   });
 
   it("shows terminal step after clicking Open shell", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     fireEvent.click(screen.getByRole("button", { name: /Open shell/i }));
@@ -113,7 +113,7 @@ describe("ExecModal", () => {
   });
 
   it("calls onClose when Cancel clicked on config step", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     const onClose = vi.fn();
     render(<ExecModal stack={stack} onClose={onClose} />);
     fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
@@ -122,7 +122,7 @@ describe("ExecModal", () => {
   });
 
   it("service select onChange updates selected service", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     const select = screen.getByRole("combobox", { name: /service/i });
@@ -132,7 +132,7 @@ describe("ExecModal", () => {
   });
 
   it("service TextInput onChange updates selected service when no services loaded", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await act(async () => {});
     const input = screen.getByPlaceholderText(/service name/i);
@@ -141,7 +141,7 @@ describe("ExecModal", () => {
   });
 
   it("command TextInput onChange updates shell value", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await act(async () => {});
     const cmdInput = screen.getByPlaceholderText(/\/bin\/sh/i);
@@ -150,7 +150,7 @@ describe("ExecModal", () => {
   });
 
   it("user TextInput onChange updates user value", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await act(async () => {});
     const userInput = screen.getByPlaceholderText(/root/i);
@@ -160,7 +160,7 @@ describe("ExecModal", () => {
 
   it("launchTerminal sets up channel and terminal when requestAnimationFrame fires", async () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
@@ -177,7 +177,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     await act(async () => {
@@ -199,7 +199,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     await act(async () => {
@@ -220,7 +220,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     await act(async () => {
@@ -238,7 +238,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     await act(async () => {
@@ -257,7 +257,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     await act(async () => {
@@ -273,7 +273,7 @@ describe("ExecModal", () => {
   });
 
   it("cockpit-style event does nothing when terminal is not yet active", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await act(async () => {});
     await act(async () => {
@@ -287,7 +287,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     await act(async () => {
@@ -305,7 +305,7 @@ describe("ExecModal", () => {
   });
 
   it("launchTerminal returns early when selected service is empty", async () => {
-    mockSpawn.mockReturnValue(mockProcess(""));
+    mockSpawn.mockImplementation(() => mockProcess(""));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await act(async () => {});
     // Button is disabled (no service), but fireEvent bypasses disabled state in jsdom
@@ -319,7 +319,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     const userInput = screen.getByPlaceholderText(/root/i);
@@ -339,7 +339,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     fireEvent.change(screen.getByLabelText(/Command/i), { target: { value: '/app/mybin "an arg with spaces"' } });
@@ -359,7 +359,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     await act(async () => {
@@ -381,7 +381,7 @@ describe("ExecModal", () => {
     vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
     const mockCockpit = { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) };
     vi.stubGlobal("cockpit", mockCockpit);
-    mockSpawn.mockReturnValue(mockProcess(composeYaml));
+    mockSpawn.mockImplementation(() => mockProcess(composeYaml));
     render(<ExecModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("option", { name: "web" }));
     await act(async () => {
@@ -415,7 +415,7 @@ describe("ExecModal", () => {
     });
 
     it("wires the command field to a datalist for browser-native suggestions", async () => {
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<ExecModal stack={stack} onClose={vi.fn()} />);
       const input = screen.getByLabelText(/Command/i) as HTMLInputElement;
       expect(input.getAttribute("list")).toBeTruthy();
@@ -425,7 +425,7 @@ describe("ExecModal", () => {
     it("records the command on launch, and it appears as a suggestion in a freshly mounted modal", async () => {
       vi.stubGlobal("requestAnimationFrame", (fn: (time: number) => void) => { fn(0); return 0; });
       vi.stubGlobal("cockpit", { spawn: mockSpawn, channel: vi.fn().mockReturnValue(mockChannel) });
-      mockSpawn.mockReturnValue(mockProcess(composeYaml));
+      mockSpawn.mockImplementation(() => mockProcess(composeYaml));
       const { unmount } = render(<ExecModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => screen.getByRole("option", { name: "web" }));
       fireEvent.change(screen.getByLabelText(/Command/i), { target: { value: "/bin/bash" } });
@@ -434,7 +434,7 @@ describe("ExecModal", () => {
       });
       unmount();
 
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<ExecModal stack={stack} onClose={vi.fn()} />);
       const input = screen.getByLabelText(/Command/i);
       const listId = input.getAttribute("list")!;

--- a/src/components/RunModal.test.tsx
+++ b/src/components/RunModal.test.tsx
@@ -27,14 +27,14 @@ beforeEach(() => {
 describe("RunModal", () => {
   describe("config step", () => {
     it("renders modal title with stack name", async () => {
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       expect(screen.getByText(/Run — myapp/i)).toBeInTheDocument();
       await act(async () => {});
     });
 
     it("shows service field, command field, --rm checkbox, and Run button", async () => {
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       expect(screen.getByLabelText(/Command/i)).toBeInTheDocument();
       expect(screen.getByRole("checkbox", { name: /remove container/i })).toBeInTheDocument();
@@ -44,7 +44,7 @@ describe("RunModal", () => {
     });
 
     it("--rm checkbox is checked by default", async () => {
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       const checkbox = screen.getByRole("checkbox", { name: /remove container/i }) as HTMLInputElement;
       expect(checkbox.checked).toBe(true);
@@ -52,7 +52,7 @@ describe("RunModal", () => {
     });
 
     it("override entrypoint checkbox is unchecked by default and shows args help text", async () => {
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       const checkbox = screen.getByRole("checkbox", { name: /override entrypoint/i }) as HTMLInputElement;
       expect(checkbox.checked).toBe(false);
@@ -61,7 +61,7 @@ describe("RunModal", () => {
     });
 
     it("toggling override entrypoint shows override help text", async () => {
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       fireEvent.click(screen.getByRole("checkbox", { name: /override entrypoint/i }));
       expect(screen.getByText(/replaces the image's entrypoint entirely/i)).toBeInTheDocument();
@@ -69,21 +69,21 @@ describe("RunModal", () => {
     });
 
     it("populates service selector from compose YAML", async () => {
-      mockSpawn.mockReturnValue(mockProcess(composeYaml));
+      mockSpawn.mockImplementation(() => mockProcess(composeYaml));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => expect(screen.getByRole("option", { name: "web" })).toBeInTheDocument());
       expect(screen.getByRole("option", { name: "db" })).toBeInTheDocument();
     });
 
     it("Run button is disabled when command is empty", async () => {
-      mockSpawn.mockReturnValue(mockProcess(composeYaml));
+      mockSpawn.mockImplementation(() => mockProcess(composeYaml));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => screen.getByRole("option", { name: "web" }));
       expect(screen.getByRole("button", { name: /^Run$/i })).toBeDisabled();
     });
 
     it("Run button is enabled once service and command are filled", async () => {
-      mockSpawn.mockReturnValue(mockProcess(composeYaml));
+      mockSpawn.mockImplementation(() => mockProcess(composeYaml));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => screen.getByRole("option", { name: "web" }));
       await act(async () => {
@@ -93,7 +93,7 @@ describe("RunModal", () => {
     });
 
     it("calls onClose when Cancel clicked", async () => {
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       const onClose = vi.fn();
       render(<RunModal stack={stack} onClose={onClose} />);
       fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
@@ -103,14 +103,14 @@ describe("RunModal", () => {
 
     it("uses first ConfigFile from comma-separated list", async () => {
       const multiStack: ComposeStack = { ...stack, ConfigFiles: "/a.yml, /b.yml" };
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<RunModal stack={multiStack} onClose={vi.fn()} />);
       await act(async () => {});
       expect(mockSpawn.mock.calls[0][0]).toContain("/a.yml");
     });
 
     it("changing service selection updates the selected service", async () => {
-      mockSpawn.mockReturnValue(mockProcess(composeYaml));
+      mockSpawn.mockImplementation(() => mockProcess(composeYaml));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => screen.getByRole("option", { name: "db" }));
       fireEvent.change(screen.getByRole("combobox", { name: /service/i }), { target: { value: "db" } });
@@ -119,7 +119,7 @@ describe("RunModal", () => {
     });
 
     it("shows text input for service when no services found in compose file", async () => {
-      mockSpawn.mockReturnValue(mockProcess("services: {}"));
+      mockSpawn.mockImplementation(() => mockProcess("services: {}"));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => expect(screen.getByRole("textbox", { name: /service/i })).toBeInTheDocument());
       fireEvent.change(screen.getByRole("textbox", { name: /service/i }), { target: { value: "myservice" } });
@@ -140,8 +140,8 @@ describe("RunModal", () => {
     // before streamCb is set, so the stream callback never fires.
     async function clickRun(onClose = vi.fn(), runOutput = "", runError?: string) {
       mockSpawn
-        .mockReturnValueOnce(mockProcess(composeYaml))
-        .mockReturnValueOnce(mockProcess("")) // snapshotProjectContainerIds
+        .mockImplementationOnce(() => mockProcess(composeYaml))
+        .mockImplementationOnce(() => mockProcess("")) // snapshotProjectContainerIds
         .mockImplementationOnce(() => mockProcess(runOutput, runError));
       render(<RunModal stack={stack} onClose={onClose} />);
       await waitFor(() => screen.getByRole("option", { name: "web" }));
@@ -195,9 +195,9 @@ describe("RunModal", () => {
   describe("compose run command", () => {
     async function triggerRun(rm: boolean) {
       mockSpawn
-        .mockReturnValueOnce(mockProcess(composeYaml))
-        .mockReturnValueOnce(mockProcess("")) // snapshotProjectContainerIds
-        .mockReturnValueOnce(mockProcess(""));
+        .mockImplementationOnce(() => mockProcess(composeYaml))
+        .mockImplementationOnce(() => mockProcess("")) // snapshotProjectContainerIds
+        .mockImplementationOnce(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => screen.getByRole("option", { name: "web" }));
       if (!rm) {
@@ -213,9 +213,9 @@ describe("RunModal", () => {
 
     async function triggerRunOverrideEntrypoint(cmd: string) {
       mockSpawn
-        .mockReturnValueOnce(mockProcess(composeYaml))
-        .mockReturnValueOnce(mockProcess("")) // snapshotProjectContainerIds
-        .mockReturnValueOnce(mockProcess(""));
+        .mockImplementationOnce(() => mockProcess(composeYaml))
+        .mockImplementationOnce(() => mockProcess("")) // snapshotProjectContainerIds
+        .mockImplementationOnce(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => screen.getByRole("option", { name: "web" }));
       await act(async () => { fireEvent.click(screen.getByRole("checkbox", { name: /override entrypoint/i })); });
@@ -281,7 +281,7 @@ describe("RunModal", () => {
 
   describe("command history", () => {
     it("wires the command field to a datalist for browser-native suggestions", async () => {
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       const input = screen.getByLabelText(/Command/i) as HTMLInputElement;
       expect(input.getAttribute("list")).toBeTruthy();
@@ -290,8 +290,8 @@ describe("RunModal", () => {
 
     it("records the command on Run, and it appears as a suggestion in a freshly mounted modal", async () => {
       mockSpawn
-        .mockReturnValueOnce(mockProcess(composeYaml))
-        .mockReturnValueOnce(mockProcess(""))
+        .mockImplementationOnce(() => mockProcess(composeYaml))
+        .mockImplementationOnce(() => mockProcess(""))
         .mockImplementationOnce(() => mockProcess(""));
       const { unmount } = render(<RunModal stack={stack} onClose={vi.fn()} />);
       await waitFor(() => screen.getByRole("option", { name: "web" }));
@@ -304,7 +304,7 @@ describe("RunModal", () => {
       await act(async () => {});
       unmount();
 
-      mockSpawn.mockReturnValue(mockProcess(""));
+      mockSpawn.mockImplementation(() => mockProcess(""));
       render(<RunModal stack={stack} onClose={vi.fn()} />);
       const input = screen.getByLabelText(/Command/i);
       const listId = input.getAttribute("list")!;

--- a/src/components/YamlModal.test.tsx
+++ b/src/components/YamlModal.test.tsx
@@ -72,46 +72,46 @@ beforeEach(() => {
 
 describe("YamlModal", () => {
   it("renders modal title with stack name", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     expect(screen.getByText(/myapp — compose file/i)).toBeInTheDocument();
     await act(async () => {});
   });
 
   it("shows spinner while loading", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
     await act(async () => {});
   });
 
   it("displays compose file content after loading", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.queryByRole("progressbar")).toBeNull());
     expect(screen.getByTestId("yaml-editor")).toBeInTheDocument();
   });
 
   it("shows config file path", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText("/path/compose.yml")).toBeInTheDocument());
   });
 
   it("shows error alert when compose file cannot be read", async () => {
-    mockSpawn.mockReturnValue(mockProcess("", "file not found"));
+    mockSpawn.mockImplementation(() => mockProcess("", "file not found"));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/Could not read file/i)).toBeInTheDocument());
   });
 
   it("shows Edit button when not in edit mode", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /Edit/i })).toBeInTheDocument());
   });
 
   it("enters edit mode and shows Save/Cancel buttons on Edit click", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
@@ -120,7 +120,7 @@ describe("YamlModal", () => {
   });
 
   it("Cancel reverts to read mode", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
@@ -135,7 +135,7 @@ describe("YamlModal", () => {
       restore: vi.fn(),
       remove: vi.fn(),
     });
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /History/i })).toBeInTheDocument());
   });
@@ -147,7 +147,7 @@ describe("YamlModal", () => {
       restore: vi.fn(),
       remove: vi.fn(),
     });
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /History/i }));
     fireEvent.click(screen.getByRole("button", { name: /History/i }));
@@ -165,7 +165,7 @@ describe("YamlModal", () => {
       restore,
       remove: vi.fn(),
     });
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /History/i }));
     fireEvent.click(screen.getByRole("button", { name: /History/i }));
@@ -182,7 +182,7 @@ describe("YamlModal", () => {
       restore: vi.fn(),
       remove,
     });
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /History/i }));
     fireEvent.click(screen.getByRole("button", { name: /History/i }));
@@ -191,7 +191,7 @@ describe("YamlModal", () => {
   });
 
   it("Lock button while editing returns to read mode without resetting content", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
@@ -201,17 +201,23 @@ describe("YamlModal", () => {
   });
 
   it("Save with no changes exits editing without saving", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
+    // readComposeFile() now tries cockpit.file() first (this test's default mock has no
+    // `read`, so it falls back to the mockSpawn-based `cat` above) — that's an expected read,
+    // not a save, so assert on the write side (replace) specifically rather than on
+    // cockpit.file() having been called at all.
+    const replace = vi.fn().mockResolvedValue(undefined);
+    mockCockpitFile.mockReturnValue({ replace });
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Save/i }));
     await waitFor(() => expect(screen.queryByRole("button", { name: /Save/i })).toBeNull());
-    expect(mockCockpitFile).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
   });
 
   it("Save with changes saves the file", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
@@ -222,7 +228,7 @@ describe("YamlModal", () => {
   });
 
   it("Save with invalid YAML shows confirm modal with errors", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
@@ -233,7 +239,7 @@ describe("YamlModal", () => {
   });
 
   it("Confirm Save Anyway button saves despite errors", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
@@ -248,7 +254,7 @@ describe("YamlModal", () => {
   });
 
   it("Confirm Save Cancel dismisses the confirm modal", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Edit/i }));
     fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
@@ -263,13 +269,13 @@ describe("YamlModal", () => {
   });
 
   it("shows Env file button after loading", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /Env file/i })).toBeInTheDocument());
   });
 
   it("clicking Env file button opens the env modal", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /Env file/i }));
     fireEvent.click(screen.getByRole("button", { name: /Env file/i }));
@@ -279,13 +285,13 @@ describe("YamlModal", () => {
 
 describe("YamlModal — add file", () => {
   it("shows Add file button after loading", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /^Add$/i })).toBeInTheDocument());
   });
 
   it("clicking Add file opens sub-modal", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Add$/i }));
@@ -294,7 +300,7 @@ describe("YamlModal — add file", () => {
   });
 
   it("Create file with empty name shows error", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Add$/i }));
@@ -303,7 +309,7 @@ describe("YamlModal — add file", () => {
   });
 
   it("Create file with invalid extension shows error", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Add$/i }));
@@ -314,7 +320,7 @@ describe("YamlModal — add file", () => {
   });
 
   it("Create file with path separator shows error", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Add$/i }));
@@ -326,7 +332,7 @@ describe("YamlModal — add file", () => {
   it("Create file with valid name writes file and calls onFileAdded", async () => {
     const mockReplace = vi.fn().mockResolvedValue(undefined);
     mockCockpitFile.mockReturnValue({ replace: mockReplace });
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     const onFileAdded = vi.fn();
     render(<YamlModal stack={stack} onClose={vi.fn()} onFileAdded={onFileAdded} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
@@ -343,7 +349,7 @@ describe("YamlModal — add file", () => {
   });
 
   it("after creation the add-file sub-modal closes", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Add$/i }));
@@ -357,21 +363,21 @@ describe("YamlModal — add file", () => {
 
 describe("YamlModal — delete file", () => {
   it("Delete file button is not shown on the primary tab", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /^Add$/i })).toBeInTheDocument());
     expect(screen.queryByRole("button", { name: /Delete file/i })).toBeNull();
   });
 
   it("Delete file button is not shown on primary tab of multi-file stack", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={multiFileStack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /^Add$/i })).toBeInTheDocument());
     expect(screen.queryByRole("button", { name: /Delete file/i })).toBeNull();
   });
 
   it("Delete file button is shown on a child tab", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={multiFileStack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("tab", { name: /prod\.yml/i }));
@@ -379,7 +385,7 @@ describe("YamlModal — delete file", () => {
   });
 
   it("clicking Delete file opens confirm dialog with filename", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={multiFileStack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("tab", { name: /prod\.yml/i }));
@@ -389,7 +395,7 @@ describe("YamlModal — delete file", () => {
   });
 
   it("Cancel on delete confirm closes the dialog", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={multiFileStack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("tab", { name: /prod\.yml/i }));
@@ -402,7 +408,7 @@ describe("YamlModal — delete file", () => {
   });
 
   it("confirming delete calls removeFile and onFileRemoved", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     const onFileRemoved = vi.fn();
     render(<YamlModal stack={multiFileStack} onClose={vi.fn()} onFileRemoved={onFileRemoved} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
@@ -424,13 +430,13 @@ describe("YamlModal — delete file", () => {
 
 describe("YamlModal — import file", () => {
   it("shows Import file button after loading", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /^Import$/i })).toBeInTheDocument());
   });
 
   it("clicking Import file opens modal and shows available files after scan", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     // mockImplementation creates a fresh CockpitProcess on each call so queueMicrotask
     // fires AFTER proc.stream(cb) is set, not before (mockReturnValue would pre-create
     // the process and fire the microtask before the Import button is even clicked)
@@ -446,7 +452,7 @@ describe("YamlModal — import file", () => {
   });
 
   it("filters files already in configFiles — only extras selectable", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     // compose.yml is in configFiles; extra.yml is not — only extra.yml should be selectable
     mockListYamlFilesInDir.mockImplementation(() => mockProcess("/path/compose.yml\n/path/extra.yml\n"));
     const onFileAdded = vi.fn();
@@ -461,7 +467,7 @@ describe("YamlModal — import file", () => {
   });
 
   it("shows 'no files' message when directory has no additional YAMLs", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     mockListYamlFilesInDir.mockImplementation(() => mockProcess("/path/compose.yml\n"));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Import$/i }));
@@ -470,7 +476,7 @@ describe("YamlModal — import file", () => {
   });
 
   it("clicking Import adds the file and calls onFileAdded", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     mockListYamlFilesInDir.mockImplementation(() => mockProcess("/path/staging.yml\n"));
     const onFileAdded = vi.fn();
     render(<YamlModal stack={stack} onClose={vi.fn()} onFileAdded={onFileAdded} />);
@@ -486,7 +492,7 @@ describe("YamlModal — import file", () => {
 
 describe("YamlModal — modal close (X button) handlers", () => {
   it("X button on add-file sub-modal closes it", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Add$/i }));
@@ -499,7 +505,7 @@ describe("YamlModal — modal close (X button) handlers", () => {
   });
 
   it("Cancel button on add-file sub-modal closes it", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("button", { name: /^Add$/i }));
@@ -510,7 +516,7 @@ describe("YamlModal — modal close (X button) handlers", () => {
   });
 
   it("X button on delete-confirm sub-modal closes it", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={multiFileStack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Add$/i }));
     fireEvent.click(screen.getByRole("tab", { name: /prod\.yml/i }));
@@ -524,7 +530,7 @@ describe("YamlModal — modal close (X button) handlers", () => {
   });
 
   it("X button on confirm-save sub-modal closes it", async () => {
-    mockSpawn.mockReturnValue(mockProcess(composeContent));
+    mockSpawn.mockImplementation(() => mockProcess(composeContent));
     render(<YamlModal stack={stack} onClose={vi.fn()} />);
     await waitFor(() => screen.getByRole("button", { name: /^Edit$/i }));
     // Open edit mode and trigger diagnostics warning then try to save

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -20,9 +20,20 @@ const mockHttp = vi.fn((): CockpitHttpClient => ({
   close: vi.fn(),
 }));
 
+// Fails by default for the same reason as mockHttp above — readComposeFile() now tries
+// cockpit.file() before falling back to spawning `cat`. Tests exercising the cockpit.file()
+// path override this per-test with `mockFile.mockReturnValue(mockCockpitFile(...))` (from the
+// base package's testing helpers).
+const mockFile = vi.fn(() => ({
+  read: vi.fn(() => Promise.reject(new Error("cockpit.file not mocked in this test"))),
+  replace: vi.fn(() => Promise.reject(new Error("cockpit.file not mocked in this test"))),
+  watch: vi.fn(),
+}));
+
 vi.stubGlobal("cockpit", {
   spawn: mockSpawn,
   http: mockHttp,
+  file: mockFile,
   permission: vi.fn().mockReturnValue(mockPermission),
 });
 
@@ -30,4 +41,4 @@ vi.stubGlobal("cockpit", {
 // i18n's cockpitDetector runs localStorage.getItem()
 await import("../i18n");
 
-export { mockSpawn, mockHttp };
+export { mockSpawn, mockHttp, mockFile };


### PR DESCRIPTION
## Summary
Follow-up to #290, based on real-world feedback on #289 from a low-power board — startup and container stats still spawned processes, and cockpit-bridge dispatch cost is significant on that hardware even for a single spawn.

- `readComposeFile()` now reads via `cockpit.file()` (Cockpit's native file channel — no process spawn at all) instead of spawning `cat`, falling back to the exact previous behavior on any failure. This is the single shared implementation behind 12 call sites across the app, so every one of them benefits without being touched individually. Engine-agnostic — no Docker/Podman distinction applies here.
- `getContainerStats()` now tries the engine's REST API first — one `GET /containers/{id}/stats` per container (no batch endpoint exists, unlike the CLI's single `docker stats id1 id2 ...` call), computing CPU% from the raw `cpu_stats`/`precpu_stats` delta the same way `docker stats` itself does, and falling back to the exact previous CLI behavior if a sample can't yield a usable percentage or the request fails outright.
- `checkSocketHealth()`'s one-time startup probe (spawning `docker version`/`podman ps` just to confirm a candidate socket responds) now tries `GET /version` over that socket first, before falling back to the same CLI probe (which still supplies the human-readable failure reason on genuine failure).

`detectComposeCommand()` (finding which compose binary is installed) stays CLI-based — there's no engine-API equivalent for "what's installed on this host."

### Podman verified live, not just assumed from Docker's docs
Checked both real engines against live sockets in QEMU VMs before merging this:
- `GET /version` — works identically on both.
- `GET /containers/{id}/stats?stream=false` — **does not** behave the same. Docker's daemon genuinely takes a second, ~2-second-earlier internal sample even for a single non-streaming request (`precpu_stats.system_cpu_usage` is a real, distinct value every time — verified the formula against a CPU-saturating process too: reported ~99%, correct). Podman's compat endpoint does not do this — `precpu_stats` always comes back as `total_usage: 0` with `system_cpu_usage` omitted entirely, confirmed unchanged across repeated samples on a container that had been running for over a minute. Silently computing the formula anyway wouldn't have crashed — it would have quietly shown the wrong number (lifetime average CPU, not current). `engineCpuPercent()` now explicitly detects that shape and falls back to the CLI, so Podman gets correct data (via the existing CLI path) rather than a fast wrong one.

## Test plan
- [x] `npm run test` — 1595 tests pass, including a regression test that reproduces Podman's real stats shape (copied verbatim from a live capture) and asserts it falls back rather than computing a bad percentage
- [x] `npm run lint` / `npm run typecheck` — clean
- [x] Manually verified `GET /version` and `GET /containers/{id}/stats` against real Docker and Podman sockets in QEMU VMs